### PR TITLE
Improvements of Citation Metatags in the article page.

### DIFF
--- a/htdocs/xsl/sci_arttext.xsl
+++ b/htdocs/xsl/sci_arttext.xsl
@@ -27,6 +27,7 @@
 
                             <!--Meta Google Scholar-->
                             <meta name="citation_journal_title" content="{TITLEGROUP/TITLE}"/>
+                            <meta name="citation_journal_title_abbrev" content="{TITLEGROUP/SHORTTITLE}"/>
                             <meta name="citation_publisher" content="{normalize-space(COPYRIGHT)}"/>
                             <meta name="citation_title" content="{ISSUE/ARTICLE/TITLE}"/>
                             <meta name="citation_date" content="{concat(substring(ISSUE/@PUBDATE,5,2),'/',substring(ISSUE/@PUBDATE,1,4))}"/>
@@ -37,7 +38,7 @@
                             <meta name="citation_abstract_html_url" content="{concat('http://',CONTROLINFO/SCIELO_INFO/SERVER, '/scielo.php?script=sci_abstract&amp;pid=', ISSUE/ARTICLE/@PID, '&amp;lng=', CONTROLINFO/LANGUAGE , '&amp;nrm=iso&amp;tlng=', ISSUE/ARTICLE/@TEXTLANG)}"/>
                             <meta name="citation_fulltext_html_url" content="{concat('http://',CONTROLINFO/SCIELO_INFO/SERVER, '/scielo.php?script=sci_arttext&amp;pid=', ISSUE/ARTICLE/@PID, '&amp;lng=', CONTROLINFO/LANGUAGE , '&amp;nrm=iso&amp;tlng=', ISSUE/ARTICLE/@TEXTLANG)}"/>
                             <meta name="citation_pdf_url" content="{concat('http://',CONTROLINFO/SCIELO_INFO/SERVER, '/scielo.php?script=sci_pdf&amp;pid=', ISSUE/ARTICLE/@PID, '&amp;lng=', CONTROLINFO/LANGUAGE , '&amp;nrm=iso&amp;tlng=', ISSUE/ARTICLE/@TEXTLANG)}"/>                            
-                            <xsl:apply-templates select=".//AUTHORS" mode="AUTHORS_META"/>
+                            <xsl:apply-templates select="ISSUE/ARTICLE/AUTHORS/AUTH_PERS/AUTHOR" mode="AUTHORS_META"/>
                             <meta name="citation_firstpage" content="{ISSUE/ARTICLE/@FPAGE}"/>
                             <meta name="citation_lastpage" content="{ISSUE/ARTICLE/@LPAGE}"/>
                             <meta name="citation_id" content="{ISSUE/ARTICLE/@DOI}"/>

--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -1266,16 +1266,17 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
 	</xsl:template>
 
 
-        <xsl:template match="AUTHORS" mode="AUTHORS_META">
-          <meta name="citation_authors">
+        <xsl:template match="AUTHOR" mode="AUTHORS_META">
+          <xsl:element name="meta">
+          	<xsl:attribute name="name">citation_authors</xsl:attribute>
             <xsl:attribute name="content">
-              <xsl:apply-templates select=".//AUTHOR" mode="AUTHORS_META"/>
+              <xsl:apply-templates select="." mode="AUTHOR_META"/>
             </xsl:attribute>
-          </meta>
+          </xsl:element>
         </xsl:template>
 
-        <xsl:template match="AUTHOR" mode="AUTHORS_META">
-          <xsl:apply-templates select=".//SURNAME"/>,<xsl:apply-templates select=".//NAME"/>;
+        <xsl:template match="AUTHOR" mode="AUTHOR_META">
+          <xsl:apply-templates select=".//SURNAME"/>, <xsl:apply-templates select=".//NAME"/>
         </xsl:template>
 
         <xsl:template match="AUTHORS" mode="AUTHORS_META_DC">


### PR DESCRIPTION
Hi Fabio:  Here is the set of tags we currently handle with examples.
I have added an empty
line between each group so as to make it easier to use as a reference.
Below the list of tags, I have listed the group of tags that would
cover common classes of cited references. Let me know if there are classes
of references that these don't cover.

The recently added metatags are:
citation_journal_abbrev -- for journal abbreviations
citation_author_institution - for author affiliation
citation_author_email - for author affiliation
citation_reference

The affiliation tags for an author would be immediately after the
citation_author tag.

As always, I will be happy to answer questions (over email or phone).

cheers,
anurag
