### PR TITLE
Novo status no historico dos periódicos: não é acesso aberto

### DIFF
--- a/cgi-bin/ScieloXML/sci_journal.xis
+++ b/cgi-bin/ScieloXML/sci_journal.xis
@@ -18,15 +18,17 @@
 		,if p(v710) then
 			'   <CHANGESINFO><NEWTITLE><TITLE',| ISSN="|v400|"|,'><![CDATA[',v710,']]></TITLE></NEWTITLE></CHANGESINFO>'/
 		,fi,
-
+        
 		
 		'		<periods>'/,
-	   ('		<period>'/,
-		,'			<begin date="',v51^a,'" status="',v51^b,'"/>'/
+	   (
+	    ,if v51^a<>'00000000' then
+	       ,'		<date-status date="',v51^a,'" status="',v51^b,'"/>'/,
+	    ,fi,
 		,if p(v51^d) then
-		,'			<end date="',v51^c,'" status="',v51^d,'"/>'/
+		  ,'		<date-status date="',v51^c,'" status="',v51^d,'"/>'/,
 		,fi,
-	   ,'</period>'/)
+	   )
 		
 		,'</periods>'/
 		

--- a/htdocs/xml/journalStatus.xml
+++ b/htdocs/xml/journalStatus.xml
@@ -1,1 +1,70 @@
-<?xml version="1.0" encoding="UTF-8"?><journal-status-translations>	<translation lang="pt">		<term code="CURRENT-SITUATION">Situação atual do periódico na coleção: </term>		<term code="D">Terminado </term>		<term code="S">Indexação interrompida pelo Comitê</term>		<term code="T">Publicação finalizada </term>		<term code="C">Corrente </term>		<term code="">Corrente </term>		<term code="certified">Períodos em que o periódico está de acordo com os criterios da coleção </term>		<term code="since">desde </term>		<term code="current">atual </term>		<term code="current-titles">Títulos correntes</term>		<term code="not-current-titles">Títulos não-correntes</term>		<term code="journal-list"> periódicos listados</term>		<term code="continue-as">Continua como </term>		<term code="finished">Publicação finalizada</term>		<term code="interrupted">Indexação interrompida pelo Comitê</term>		<term code="in">em </term>		<term code="hist">Histórico do periódico na coleção COLLECTION_NAME</term>		<term code="admitted">Admitido à coleção COLLECTION_NAME</term>		<term code="readmitted">Readmitido à coleção COLLECTION_NAME, pelo Comitê Consultivo</term>	</translation>	<translation lang="es">		<term code="CURRENT-SITUATION">Estado actual de la revista en la colección: </term>		<term code="D">Terminado </term>		<term code="S">Indización interrumpida por el comité</term>		<term code="T">Publicación finalizada </term>		<term code="C">Vigente </term>		<term code="">Vigente </term>		<term code="certified">Períodos en que la revista está de acuerdo con los criterios de la colección </term>		<term code="since">desde </term>		<term code="current">actual</term>		<term code="current-titles">Títulos vigentes</term>		<term code="not-current-titles">Títulos no vigentes</term>		<term code="journal-list"> seriadas listadas</term>		<term code="continue-as">Continua como </term>		<term code="finished">Publicación finalizada</term>		<term code="interrupted">Indización interrumpida por el comité </term>		<term code="in">en </term>		<term code="hist">Histórico de la revista en la colección COLLECTION_NAME</term>		<term code="admitted">Admitido a la colección COLLECTION_NAME</term>		<term code="readmitted">Readmitido a la colección COLLECTION_NAME, por el comité</term>	</translation>	<translation lang="en">		<term code="CURRENT-SITUATION">Current status of the journal in the collection: </term>		<term code="D">Deceased </term>		<term code="S">Indexing interrupted by committee </term>		<term code="T">Publication finished </term>		<term code="C">Current </term>		<term code="">Current </term>		<term code="certified">Period in which the journal is according to the collection's criteria </term>		<term code="since">since </term>		<term code="current">current</term>		<term code="current-titles">Current titles</term>		<term code="not-current-titles">Non-current titles</term>		<term code="journal-list"> serials listed</term>		<term code="continue-as">Continued as </term>		<term code="finished">Publication finished </term>		<term code="interrupted">Indexing interrupted by the committee </term>		<term code="in">in </term>		<term code="hist">Journal's history in COLLECTION_NAME collection</term>		<term code="admitted">Admitted to COLLECTION_NAME collection</term>		<term code="readmitted">Readmitted to COLLECTION_NAME collection by the committee</term>	</translation></journal-status-translations>
+<?xml version="1.0" encoding="UTF-8"?>
+<journal-status-translations>
+	<translation lang="pt">
+		<term code="CURRENT-SITUATION">Situação atual do periódico na coleção: </term>
+		<term code="D">Terminado </term>
+		<term code="S">Indexação interrompida pelo Comitê</term>
+		<term code="E">deixou de publicar em acesso aberto</term>
+		<term code="C">Corrente </term>
+		<term code="">Corrente </term>
+		<term code="certified">Períodos em que o periódico está de acordo com os criterios da coleção </term>
+		<term code="since">desde </term>
+		<term code="current">atual </term>
+		<term code="current-titles">Títulos correntes</term>
+		<term code="not-current-titles">Títulos não-correntes</term>
+		<term code="journal-list"> periódicos listados</term>
+		<term code="continue-as">Continua como </term>
+		<term code="finished">Publicação finalizada</term>
+		<term code="interrupted">Indexação interrompida pelo Comitê</term>
+		<term code="in">em </term>
+		<term code="hist">Histórico do periódico na coleção COLLECTION_NAME</term>
+		<term code="admitted">Admitido à coleção COLLECTION_NAME</term>
+		<term code="readmitted">Readmitido à coleção COLLECTION_NAME, pelo Comitê Consultivo</term>
+	</translation>
+	<translation lang="es">
+		<term code="CURRENT-SITUATION">Estado actual de la revista en la colección: </term>
+		<term code="D">Terminado </term>
+		<term code="S">Indización interrumpida por el comité</term>
+		<term code="E">no publica en aceso abierto</term>
+		<term code="C">Vigente </term>
+		<term code="">Vigente </term>
+		<term code="certified">Períodos en que la revista está de acuerdo con los criterios de la colección </term>
+		<term code="since">desde </term>
+		<term code="current">actual</term>
+		<term code="current-titles">Títulos vigentes</term>
+		<term code="not-current-titles">Títulos no vigentes</term>
+		<term code="journal-list"> seriadas listadas</term>
+		<term code="continue-as">Continua como </term>
+		<term code="finished">Publicación finalizada</term>
+		<term code="interrupted">Indización interrumpida por el comité </term>
+		<term code="in">en </term>
+		<term code="hist">Histórico de la revista en la colección COLLECTION_NAME</term>
+		<term code="admitted">Admitido a la colección COLLECTION_NAME</term>
+		<term code="readmitted">Readmitido a la colección COLLECTION_NAME, por el comité</term>
+
+	</translation>
+	<translation lang="en">
+		<term code="CURRENT-SITUATION">Current status of the journal in the collection: </term>
+		<term code="D">Deceased </term>
+		<term code="S">Indexing interrupted by committee </term>
+		<term code="E">It is not open access journal</term>
+		
+		<term code="C">Current </term>
+		<term code="">Current </term>
+		<term code="certified">Period in which the journal is according to the collection's criteria </term>
+		<term code="since">since </term>
+		<term code="current">current</term>
+		<term code="current-titles">Current titles</term>
+		<term code="not-current-titles">Non-current titles</term>
+		<term code="journal-list"> serials listed</term>
+		<term code="continue-as">Continued as </term>
+		<term code="finished">Publication finished </term>
+		<term code="interrupted">Indexing interrupted by the committee </term>
+		<term code="in">in </term>
+		<term code="hist">Journal's history in COLLECTION_NAME collection</term>
+		<term code="admitted">Admitted to COLLECTION_NAME collection</term>
+		<term code="readmitted">Readmitted to COLLECTION_NAME collection by the committee</term>
+
+
+	</translation>
+</journal-status-translations>

--- a/htdocs/xsl/journalStatus.xsl
+++ b/htdocs/xsl/journalStatus.xsl
@@ -1,1 +1,107 @@
-<?xml version="1.0" encoding="utf-8"?><xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">	<xsl:variable name="translations-j" select="document('../xml/journalStatus.xml')//translation[@lang=$interfaceLang]"/>	<xsl:template match="period">		<li>			<xsl:apply-templates select=".//begin"/>-<xsl:choose>				<xsl:when test=".//end">					<xsl:apply-templates select="end"/> ( <xsl:apply-templates select="end" mode="motive"/>					<xsl:if test="../../..//journal-status-history//NEWTITLE">; <xsl:apply-templates select="../../..//journal-status-history" mode="display-status-info"/>					</xsl:if>)</xsl:when>				<xsl:otherwise>					<!--xsl:apply-templates select="." mode="display-msg-current"/-->					<xsl:value-of select="$translations-j//term[@code='current']"/>				</xsl:otherwise>			</xsl:choose>		</li>	</xsl:template>	<xsl:template match="period" mode="hist">		<xsl:if test=".//end">			<li>				<xsl:apply-templates select="end"/>: <xsl:apply-templates select="end" mode="motive"/>				<xsl:if test="../../..//journal-status-history//NEWTITLE">; <xsl:apply-templates select="../../..//journal-status-history" mode="display-status-info"/>				</xsl:if>			</li>		</xsl:if>		<li>			<xsl:apply-templates select="begin"/>: <xsl:choose>				<xsl:when test="position()=last()">					<xsl:apply-templates select="$translations-j//term[@code='admitted']" mode="translation"/>				</xsl:when>				<xsl:otherwise>					<xsl:apply-templates select="$translations-j//term[@code='readmitted']" mode="translation"/>				</xsl:otherwise>			</xsl:choose>		</li>	</xsl:template>	<xsl:template match="end | begin">		<xsl:if test="substring(@date,5,2)!='00'">			<!--xsl:value-of select="substring(@date,5,2)"/-->			<xsl:call-template name="GET_MONTH_NAME">				<xsl:with-param name="LANG" select="$interfaceLang"/>				<xsl:with-param name="MONTH" select="substring(@date,5,2)"/>				<xsl:with-param name="ABREV" select="1"/>			</xsl:call-template>&#160;		</xsl:if>		<xsl:value-of select="substring(@date,1,4)"/>	</xsl:template>	<xsl:template match="end" mode="motive">		<xsl:variable name="status" select="@status"/>		<xsl:value-of select="$translations-j//term[@code=$status]"/>	</xsl:template>	<xsl:template match="*" mode="display-msg-current-list">		<xsl:param name="count"/>		<p>			<xsl:value-of select="$translations-j//term[@code='current-titles']"/> - <xsl:value-of select="$count"/>&#160;			<xsl:value-of select="$translations-j//term[@code='journal-list']"/>		</p>	</xsl:template>	<xsl:template match="*" mode="display-msg-not-current-list">		<xsl:param name="count"/>		<p>			<xsl:value-of select="$translations-j//term[@code='not-current-titles']"/> - <xsl:value-of select="$count"/>&#160;			<xsl:value-of select="$translations-j//term[@code='journal-list']"/>		</p>	</xsl:template>	<xsl:template match="current-status/@status">		<xsl:variable name="status" select="."/>		<xsl:value-of select="$translations-j//term[@code=$status]"/>	</xsl:template>	<!--		-->	<xsl:template match="journal-status-history[.//current-status/@status='C' or .//current-status/@status='']" mode="display-status-info">	</xsl:template>	<xsl:template match="journal-status-history[.//current-status/@status!='C' and .//current-status/@status!='']" mode="display-status-info">		<!--&#160; [ -->		<span class="status-info-alphabetic-list">			<xsl:variable name="s" select=".//current-status/@status"/>			<xsl:choose>				<xsl:when test=".//NEWTITLE">					<xsl:value-of select="$translations-j//term[@code='continue-as']"/>					<xsl:apply-templates select=".//NEWTITLE"/>				</xsl:when>				<xsl:otherwise>					<xsl:value-of select="concat($translations-j//term[@code=$s],' ')"/>					<xsl:value-of select="$translations-j//term[@code='in']"/>					<xsl:call-template name="ShowDate">						<xsl:with-param name="DATEISO" select=".//@date"/>						<xsl:with-param name="LANG" select="//CONTROLINFO/LANGUAGE"/>					</xsl:call-template>				</xsl:otherwise>			</xsl:choose>		</span>	</xsl:template>	<!--		-->	<xsl:template match="journal-status-history" mode="display-periods">		<br/>		<small>			<a name="note"/>			<a class="note2" href="#top">*</a>			<xsl:apply-templates select="$translations-j//term[@code='certified']" mode="translation"/>		</small>		<ul>			<xsl:apply-templates select=".//period"/>		</ul>	</xsl:template>	<xsl:template match="journal-status-history" mode="display-hist">		<br/>		<small>			<a name="note"/>			<a class="note2" href="#top">*</a>			<xsl:apply-templates select="$translations-j//term[@code='hist']" mode="translation"/>		</small>		<ul>			<xsl:apply-templates select=".//period" mode="hist"/>		</ul>	</xsl:template>	<!--xsl:template match="*" mode="journal-info">		<xsl:if test=".//current-status/@status!='C'">			<TABLE width="100%" border="0">				<TBODY>					<tr>						<td>&#160;</td>						<td width="95%">							<table>								<tbody>									<tr>										<td>											<xsl:apply-templates select=".//current-status/@status"/>										</td>									</tr>									<xsl:if test="//journal-status-history//CHANGESINFO">										<TR>											<TD>												<BR/>												<xsl:apply-templates select="//journal-status-history//CHANGESINFO">													<xsl:with-param name="LANG" select="//CONTROLINFO/LANGUAGE"/>												</xsl:apply-templates>											</TD>										</TR>									</xsl:if>								</tbody>							</table>						</td>					</tr>				</TBODY>			</TABLE>		</xsl:if>	</xsl:template-->	<xsl:template match="SERIAL" mode="journal-history">		<xsl:comment>journal-history</xsl:comment>		<p>			<!--small>				<xsl:value-of select="$translations-j//term[@code='CURRENT-SITUATION']"/>				<xsl:apply-templates select=".//journal-status-history" mode="display-status-info"/>				<xsl:if test=".//journal-status-history//current-status/@status='C' "><xsl:apply-templates select=".//journal-status-history//current-status/@status"/></xsl:if>			</small-->			<br/>			<small>				<!--xsl:apply-templates select=".//journal-status-history" mode="display-periods"/-->				<xsl:apply-templates select=".//journal-status-history" mode="display-hist"/>			</small>		</p>	</xsl:template>	<xsl:template match="term" mode="translation">		<xsl:value-of select="substring-before(.,'COLLECTION_NAME')"/>		<xsl:value-of select="$SITE_NAME"/>		<xsl:value-of select="substring-after(.,'COLLECTION_NAME')"/>	</xsl:template></xsl:stylesheet>
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:variable name="translations-j" select="document('../xml/journalStatus.xml')//translation[@lang=$interfaceLang]"/>
+	
+	<xsl:template match="term" mode="collection_name">
+		<xsl:value-of select="substring-before(.,'COLLECTION_NAME')"/>
+		<xsl:value-of select="$SITE_NAME"/>
+		<xsl:value-of select="substring-after(.,'COLLECTION_NAME')"/>
+	</xsl:template>
+	
+	<xsl:template match="date-status" mode="display-hist">
+		<li>			
+			<xsl:apply-templates select="." mode="display-hist-status"/>
+		</li>		
+	</xsl:template>
+	<xsl:template match="date-status|current-status" mode="display-hist-status">
+		<xsl:apply-templates select="@date"/>: <xsl:apply-templates select="@status"><xsl:with-param name="is_first_admission"><xsl:if test="position()=last()">yes</xsl:if></xsl:with-param></xsl:apply-templates>
+		<xsl:if test="@status='D' and ../..//NEWTITLE">;
+			<xsl:value-of select="$translations-j//term[@code='continue-as']"/> <xsl:apply-templates select="../..//NEWTITLE"/>
+		</xsl:if>				
+	</xsl:template>
+	<xsl:template match="date-status/@status | current-status/@status">
+		<xsl:param name="is_first_admission">no</xsl:param>
+		<xsl:variable name="code"><xsl:value-of select="."/></xsl:variable>
+		<xsl:choose>
+			<xsl:when test=".='C'">
+				<xsl:choose>
+					<xsl:when test="$is_first_admission='yes'">
+						<xsl:apply-templates select="$translations-j//term[@code='admitted']" mode="collection_name"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:apply-templates select="$translations-j//term[@code='readmitted']" mode="collection_name"/>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:when>
+			<xsl:otherwise><xsl:value-of select="$translations-j//term[@code=$code]"/></xsl:otherwise>
+		</xsl:choose>		
+	</xsl:template>
+	
+	<xsl:template match="date-status/@date | current-status/@date">
+		<xsl:if test="substring(.,5,2)!='00'">
+			<xsl:call-template name="GET_MONTH_NAME">
+				<xsl:with-param name="LANG" select="$interfaceLang"/>
+				<xsl:with-param name="MONTH" select="substring(.,5,2)"/>
+				<xsl:with-param name="ABREV" select="1"/>
+			</xsl:call-template>&#160;
+		</xsl:if>
+		<xsl:value-of select="substring(.,1,4)"/>
+	</xsl:template>
+	
+	
+	
+	<xsl:template match="*" mode="display-msg-current-list">
+		<xsl:param name="count"/>
+		<p>
+			<xsl:value-of select="$translations-j//term[@code='current-titles']"/>
+ - <xsl:value-of select="$count"/>&#160;
+			<xsl:value-of select="$translations-j//term[@code='journal-list']"/>
+		</p>
+	</xsl:template>
+	<xsl:template match="*" mode="display-msg-not-current-list">
+		<xsl:param name="count"/>
+		<p>
+			<xsl:value-of select="$translations-j//term[@code='not-current-titles']"/>
+ - <xsl:value-of select="$count"/>&#160;
+			<xsl:value-of select="$translations-j//term[@code='journal-list']"/>
+		</p>
+	</xsl:template>
+	
+	
+	<!--
+	
+	-->
+	
+	<xsl:template match="journal-status-history" mode="display-status-info">
+		<xsl:if test=".//current-status/@status!='C' and .//current-status/@status!=''">
+			<!--&#160; [ -->
+			<span class="status-info-alphabetic-list">
+				<xsl:apply-templates select=".//current-status" mode="display-hist-status"></xsl:apply-templates>
+			</span>
+		</xsl:if>
+		
+	</xsl:template>
+	
+	<xsl:template match="journal-status-history" mode="display-hist">
+		<br/>
+		<small>
+			<a name="note"/>
+			<a class="note2" href="#top">*</a>
+			<xsl:apply-templates select="$translations-j//term[@code='hist']" mode="collection_name"/>
+		</small>
+		<ul>
+			<xsl:apply-templates select=".//date-status" mode="display-hist"/>
+		</ul>
+	</xsl:template>
+	
+	<xsl:template match="SERIAL" mode="journal-history">
+		<xsl:comment>journal-history</xsl:comment>
+		<p>			
+			<br/>
+			<small>
+				<xsl:apply-templates select=".//journal-status-history" mode="display-hist"/>
+			</small>
+		</p>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/htdocs/xsl/sci_subject.xsl
+++ b/htdocs/xsl/sci_subject.xsl
@@ -118,8 +118,8 @@
 				<xsl:value-of select="$text_issues"/>
 				<xsl:if test="@QTYISS > 1">s</xsl:if>
 			</xsl:if>
-			<xsl:if test=".//current-status/@status!='' and .//current-status/@status!='C' ">
-				<xsl:apply-templates select="." mode="display-status-info"/>
+			<xsl:if test=".//current-status/@status!='' and .//current-status/@status!='C' "> - 
+				<xsl:apply-templates select=".//journal-status-history" mode="display-status-info"/>
 			</xsl:if>
 		</font>
 		<br/>


### PR DESCRIPTION
Permitir a indicação de que o periódico não faz mais parte da coleção por não publicar open access
