### PR TITLE
Corrige título de resumo.

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -334,26 +334,24 @@
 			<xsl:attribute name="class">
 				<xsl:value-of select="name()"/>
 			</xsl:attribute>
-			<xsl:if test="not(title)">
+			<p class="sec">
 				<xsl:choose>
+					<xsl:when test="title">
+						<a name="{title}"><xsl:value-of select="title"/></a>
+					</xsl:when>
 					<xsl:when test="$lang='pt'">
-						<p class="sec">
-							<a name="resumo">RESUMO</a>
-						</p>
+						<a name="resumo">RESUMO</a>
 					</xsl:when>
 					<xsl:when test="$lang='es'">
-						<p class="sec">
-							<a name="resumen">RESUMEN</a>
-						</p>
+						<a name="resumen">RESUMEN</a>
 					</xsl:when>
 					<xsl:otherwise>
-						<p class="sec">
-							<a name="abstract">ABSTRACT</a>
-						</p>
+						<a name="abstract">ABSTRACT</a>
 					</xsl:otherwise>
 				</xsl:choose>
-			</xsl:if>
-			<xsl:apply-templates select="* | text()"/>
+			</p>
+			
+			<xsl:apply-templates select="*[name()!='title'] | text()"/>
 			<xsl:apply-templates
 				select="..//kwd-group[normalize-space(@xml:lang)=normalize-space($lang)]"
 				mode="keywords-with-abstract"/>

--- a/htdocs/xsl/sci_abstract.xsl
+++ b/htdocs/xsl/sci_abstract.xsl
@@ -179,8 +179,15 @@
 	<xsl:template match="ABSTRACT//*">
 		<xsl:apply-templates select="*|text()"/>
 	</xsl:template>
-	<xsl:template match="ABSTRACT/sec/title"><p class="subsec">
-		<xsl:apply-templates select="*|text()"/></p>
+	<xsl:template match="ABSTRACT//p">
+		<p>
+			<xsl:apply-templates select="*|text()"/>
+		</p>
+	</xsl:template>
+	<xsl:template match="ABSTRACT/title">
+	</xsl:template>
+	<xsl:template match="ABSTRACT/sec/title">
+		<p class="subsec"><xsl:apply-templates select="*|text()"/></p>
 	</xsl:template>
 	<xsl:template match="ABSTRACT/sec"><div>
 		<xsl:apply-templates select="*|text()"/></div>


### PR DESCRIPTION
Na página do resumo remover o título quando é igual a "Resumo".
Na página do texto completo ajustar o estilo do título "Resumo".

Fixes #320