### PR TITLE
Show abstract with sections in plus version

### DIFF
--- a/htdocs/xsl/plus/data.xsl
+++ b/htdocs/xsl/plus/data.xsl
@@ -314,9 +314,15 @@
         <xsl:if test="not(.//title)">Key words</xsl:if>
     </xsl:template>
     <xsl:template match="abstract|trans-abstract" mode="DATA-DISPLAY-TITLE">
-
-        <xsl:apply-templates select="title"/>
-        <xsl:if test="not(.//title)">Abstract</xsl:if>
+        <xsl:param name="lang"/>
+        <xsl:choose>
+            <xsl:when test="title">
+                <xsl:apply-templates select="title"/>
+            </xsl:when>
+            <xsl:when test="$lang='pt'">Resumo</xsl:when>
+            <xsl:when test="$lang='es'">Resumen</xsl:when>
+            <xsl:otherwise>Abstract</xsl:otherwise>
+        </xsl:choose>
         <!-- FIXME -->
 
     </xsl:template>

--- a/htdocs/xsl/plus/layout.xsl
+++ b/htdocs/xsl/plus/layout.xsl
@@ -422,13 +422,19 @@
         <h1>
             <xsl:choose>
                 <xsl:when test="front-stub//abstract">
-                    <xsl:apply-templates select="front-stub//abstract" mode="DATA-DISPLAY-TITLE"/>
+                    <xsl:apply-templates select="front-stub//abstract" mode="DATA-DISPLAY-TITLE">
+                        <xsl:with-param name="lang" select="$lang"></xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:when>
                 <xsl:when test="front//trans-abstract[@xml:lang=$lang]">
-                    <xsl:apply-templates select="front//trans-abstract[@xml:lang=$lang]" mode="DATA-DISPLAY-TITLE"/>
+                    <xsl:apply-templates select="front//trans-abstract[@xml:lang=$lang]" mode="DATA-DISPLAY-TITLE">
+                        <xsl:with-param name="lang" select="$lang"></xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:apply-templates select="front//abstract" mode="DATA-DISPLAY-TITLE"/>
+                    <xsl:apply-templates select="front//abstract" mode="DATA-DISPLAY-TITLE">
+                        <xsl:with-param name="lang" select="$lang"></xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:otherwise>
             </xsl:choose>
         </h1>
@@ -436,13 +442,13 @@
             <div class="span8">
                 <xsl:choose>
                     <xsl:when test="front-stub//abstract">
-                        <xsl:apply-templates select="front-stub//abstract" mode="DATA-DISPLAY"/>
+                        <xsl:apply-templates select="front-stub//abstract/*[name()!='title'] | front-stub//abstract/text()" mode="HTML-TEXT"/>
                     </xsl:when>
                     <xsl:when test="front//trans-abstract[@xml:lang=$lang]">
-                        <xsl:apply-templates select="front//trans-abstract[@xml:lang=$lang]" mode="DATA-DISPLAY"/>
+                        <xsl:apply-templates select="front//trans-abstract[@xml:lang=$lang]/*[name()!='title'] | front//trans-abstract[@xml:lang=$lang]/text()" mode="HTML-TEXT"/>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:apply-templates select="front//abstract" mode="DATA-DISPLAY"/>
+                        <xsl:apply-templates select="front//abstract/*[name()!='title'] | front//abstract/text()" mode="HTML-TEXT"/>
                     </xsl:otherwise>
                 </xsl:choose>
                 <xsl:choose>


### PR DESCRIPTION
Las secciones en los abstract no se visualizan de forma correcta en la versión plus, se realizaron cambios para presentar el título de la sección de resumen, así como la presentación de la secciones