### PR TITLE
Clean label from mixed-citation, to clear view

### DIFF
--- a/htdocs/xsl/plus/layout.xsl
+++ b/htdocs/xsl/plus/layout.xsl
@@ -684,6 +684,14 @@
             select="concat(substring-before($SERVICE_REFERENCE_LINKS,'REFERENCE_ID'),$p,substring-after($SERVICE_REFERENCE_LINKS,'REFERENCE_ID'))"
         />
     </xsl:template>
+    <xsl:template match="label" mode="display-only-if-number">
+        <xsl:variable name="label">
+            <xsl:value-of select="translate(., '.', '')"/>
+        </xsl:variable>
+        <xsl:if test="number($label) = $label">
+            <xsl:value-of select="."/>
+        </xsl:if>
+    </xsl:template>
     <xsl:template match="ref" mode="HTML-TEXT">
         <xsl:variable name="link">
             <xsl:apply-templates select="." mode="REFERENCE-LINKS">
@@ -708,7 +716,7 @@
         <li class="clearfix">
             <a name="{@id}"/>
             <sup class="xref big pull-left">
-                <xsl:apply-templates select="label"/>
+                <xsl:apply-templates select="label" mode="display-only-if-number"/>
             </sup>
             <div class="pull-right">
                 <xsl:choose>

--- a/htdocs/xsl/plus/layout.xsl
+++ b/htdocs/xsl/plus/layout.xsl
@@ -3,7 +3,8 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
-    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" exclude-result-prefixes="xs math xd"
+    xmlns:exsl="http://exslt.org/common"
+    exclude-result-prefixes="xs math exsl"
     version="3.0">
     <xsl:template match="*[@xlink:href] | *[@href]" mode="fix_img_extension">
         <xsl:variable name="href"><xsl:choose>
@@ -691,6 +692,19 @@
                 </xsl:with-param>
             </xsl:apply-templates>
         </xsl:variable>
+        <xsl:variable name="rtf-mixed-citation">
+            <xsl:choose>
+                <xsl:when test="label">
+                    <xsl:apply-templates select="mixed-citation" mode="without-label">
+                        <xsl:with-param name="label" select="label"/>
+                    </xsl:apply-templates>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="mixed-citation"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="mixed-citation" select="exsl:node-set($rtf-mixed-citation)/node()"/>
         <li class="clearfix">
             <a name="{@id}"/>
             <sup class="xref big pull-left">
@@ -699,14 +713,14 @@
             <div class="pull-right">
                 <xsl:choose>
 
-                    <xsl:when test="element-citation[.//ext-link] and mixed-citation[not(.//ext-link)] or element-citation[.//uri] and mixed-citation[not(.//uri)] ">
-                        <xsl:apply-templates select="mixed-citation" mode="with-link">
+                    <xsl:when test="element-citation[.//ext-link] and $mixed-citation[not(.//ext-link)] or element-citation[.//uri] and $mixed-citation[not(.//uri)] ">
+                        <xsl:apply-templates select="$mixed-citation" mode="with-link">
                             <xsl:with-param name="ext_link" select=".//ext-link"/>
                             <xsl:with-param name="uri" select=".//uri"/>
                         </xsl:apply-templates>
                     </xsl:when>
-                    <xsl:when test="mixed-citation">
-                        <xsl:apply-templates select="mixed-citation"/>
+                    <xsl:when test="$mixed-citation">
+                        <xsl:apply-templates select="$mixed-citation"/>
                     </xsl:when>
                     <xsl:when test="citation">
                         <xsl:apply-templates select="citation"/>
@@ -1421,6 +1435,17 @@ Weaver, William. The Collectors: command performances. Photography by Robert Emm
         <a href="{@xlink:href}" target="_blank">
             <xsl:value-of select="."/>
         </a>
+    </xsl:template>
+    <xsl:template match="mixed-citation" mode="without-label">
+        <xsl:param name="label"/>
+        <xsl:element name="{name()}">
+            <xsl:choose>
+                <xsl:when test="$label and starts-with(normalize-space(.), normalize-space($label))">
+                    <xsl:value-of select="normalize-space(substring-after(., $label))"/>
+                </xsl:when>
+                <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
     </xsl:template>
     <xsl:template match="mixed-citation" mode="with-link">
         <xsl:param name="uri"/>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML">
+	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+	xmlns:exsl="http://exslt.org/common"
+	exclude-result-prefixes="exsl">
 	
 	
 	<xsl:variable name="trans"
@@ -941,7 +943,9 @@
 					</xsl:otherwise>
 				</xsl:choose>
 			</p>
-			<xsl:apply-templates select="ref"/>
+			<ul class="ref-list">
+				<xsl:apply-templates select="ref"/>
+			</ul>
 		</div>
 	</xsl:template>
 	<xsl:template match="sub-article[@article-type='translation']/back/ref-list">
@@ -954,7 +958,9 @@
 					<xsl:apply-templates select="$title"></xsl:apply-templates>
 				</xsl:if>
 			</p>
-			<xsl:apply-templates select="$original/back/ref-list/ref"/>
+			<ul class="ref-list">
+				<xsl:apply-templates select="$original/back/ref-list/ref"/>
+			</ul>
 		</div>
 	</xsl:template>
 	<xsl:template match="sub-article[@article-type='translation']/response/back/ref-list">
@@ -967,64 +973,69 @@
 					<xsl:apply-templates select="$title"></xsl:apply-templates>
 				</xsl:if>
 			</p>
-			<xsl:apply-templates select="$original/response/back/ref-list/ref"/>
+			<ul class="ref-list">
+				<xsl:apply-templates select="$original/response/back/ref-list/ref"/>
+			</ul>
 		</div>
 	</xsl:template>
 	
 	<xsl:template match="ref">
-		<p class="ref">
-			<a name="{@id}"/>
+		<xsl:variable name="rtf-mixed-citation">
 			<xsl:choose>
-				<xsl:when test="label and mixed-citation">
-					<xsl:choose>
-						<xsl:when test="substring(normalize-space(mixed-citation),1,string-length(normalize-space(label)))=normalize-space(label)">
-							<xsl:apply-templates select="mixed-citation"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="label"/><xsl:if test="not(contains(label,'.')) and substring(normalize-space(mixed-citation),1,1)!='.'">.&#160; </xsl:if><xsl:apply-templates select="mixed-citation"/>
-						</xsl:otherwise>
-					</xsl:choose>
+				<xsl:when test="label">
+					<xsl:apply-templates select="mixed-citation" mode="without-label">
+						<xsl:with-param name="label" select="label"/>
+					</xsl:apply-templates>
 				</xsl:when>
 				<xsl:otherwise>
-					<xsl:if test="label"><xsl:value-of select="label"/><xsl:if test="not(contains(label,'.'))">.&#160; </xsl:if></xsl:if>
-					<xsl:choose>
-						<xsl:when
-							test="(element-citation[.//ext-link] and mixed-citation[not(.//ext-link)]) or (element-citation[.//uri] and mixed-citation[not(.//uri)])">
-							<xsl:apply-templates select="mixed-citation" mode="with-link">
-								<xsl:with-param name="ext_link" select=".//ext-link"/>
-								<xsl:with-param name="uri" select=".//uri"/>
-							</xsl:apply-templates>
-						</xsl:when>
-						<xsl:when test="mixed-citation">
-							<xsl:apply-templates select="mixed-citation"/>
-						</xsl:when>
-						<xsl:when test="citation">
-							<xsl:apply-templates select="citation"/>
-						</xsl:when>
-						<!--xsl:when test="element-citation">
-					<xsl:apply-templates select="element-citation"/>
-				</xsl:when>
-				<xsl:when test="citation">
-					<xsl:apply-templates select="citation"/>
-				</xsl:when>
-				<xsl:when test="nlm-citation">
-					<xsl:apply-templates select="nlm-citation"/>
-				</xsl:when-->
-						<xsl:otherwise><xsl:comment>_missing mixed-citation _</xsl:comment>
-						</xsl:otherwise>
-					</xsl:choose>
+					<xsl:copy-of select="mixed-citation"/>
 				</xsl:otherwise>
-			
 			</xsl:choose>
-			
-			<xsl:variable name="aref">000000<xsl:apply-templates select="."
-					mode="scift-get_position"/></xsl:variable>
-			<xsl:variable name="ref"><xsl:value-of
-					select="substring($aref, string-length($aref) - 5)"/></xsl:variable>
-			<xsl:variable name="pid"><xsl:value-of select="$PID"/><xsl:value-of
-					select="substring($ref,2)"/></xsl:variable> [&#160;<a href="javascript:void(0);"
-				onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;pid={$pid}&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');"
-				>Links</a>&#160;] </p>
+		</xsl:variable>
+		<xsl:variable name="mixed-citation" select="exsl:node-set($rtf-mixed-citation)/node()"/>
+		<li class="ref">
+			<a name="{@id}"/>
+			<xsl:if test="label">
+				<div class="label_citation"><xsl:value-of select="label"/><xsl:if test="not(contains(label,'.'))">.&#160; </xsl:if></div>
+			</xsl:if>
+			<div class="citation">
+				<xsl:choose>
+					<xsl:when
+						test="(element-citation[.//ext-link] and $mixed-citation[not(.//ext-link)]) or (element-citation[.//uri] and $mixed-citation[not(.//uri)])">
+						<xsl:apply-templates select="$mixed-citation" mode="with-link">
+							<xsl:with-param name="ext_link" select=".//ext-link"/>
+							<xsl:with-param name="uri" select=".//uri"/>
+						</xsl:apply-templates>
+					</xsl:when>
+					<xsl:when test="$mixed-citation">
+						<xsl:apply-templates select="$mixed-citation"/>
+					</xsl:when>
+					<xsl:when test="citation">
+						<xsl:apply-templates select="citation"/>
+					</xsl:when>
+					<!--xsl:when test="element-citation">
+						<xsl:apply-templates select="element-citation"/>
+					</xsl:when>
+					<xsl:when test="citation">
+						<xsl:apply-templates select="citation"/>
+					</xsl:when>
+					<xsl:when test="nlm-citation">
+						<xsl:apply-templates select="nlm-citation"/>
+					</xsl:when-->
+					<xsl:otherwise><xsl:comment>_missing mixed-citation _</xsl:comment>
+					</xsl:otherwise>
+				</xsl:choose>
+				
+				<xsl:variable name="aref">000000<xsl:apply-templates select="."
+						mode="scift-get_position"/></xsl:variable>
+				<xsl:variable name="ref"><xsl:value-of
+						select="substring($aref, string-length($aref) - 5)"/></xsl:variable>
+				<xsl:variable name="pid"><xsl:value-of select="$PID"/><xsl:value-of
+						select="substring($ref,2)"/></xsl:variable> [&#160;<a href="javascript:void(0);"
+					onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;pid={$pid}&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');"
+					>Links</a>&#160;]
+			</div>
+		</li>
 	</xsl:template>
 
 
@@ -1414,6 +1425,17 @@
 		<a href="{@xlink:href}" target="_blank">
 			<xsl:value-of select="."/>
 		</a>
+	</xsl:template>
+	<xsl:template match="mixed-citation" mode="without-label">
+		<xsl:param name="label"/>
+		<xsl:element name="{name()}">
+			<xsl:choose>
+				<xsl:when test="$label and starts-with(normalize-space(.), normalize-space($label))">
+					<xsl:value-of select="normalize-space(substring-after(., $label))"/>
+				</xsl:when>
+				<xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+			</xsl:choose>
+		</xsl:element>
 	</xsl:template>
 	<xsl:template match="mixed-citation" mode="with-link">
 		<xsl:param name="uri"/>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -978,6 +978,14 @@
 			</ul>
 		</div>
 	</xsl:template>
+	<xsl:template match="label" mode="display-only-if-number">
+		<xsl:variable name="label">
+			<xsl:value-of select="translate(., '.', '')"/>
+		</xsl:variable>
+		<xsl:if test="number($label) = $label">
+			<xsl:value-of select="."/>
+		</xsl:if>
+	</xsl:template>
 	
 	<xsl:template match="ref">
 		<xsl:variable name="rtf-mixed-citation">
@@ -993,10 +1001,13 @@
 			</xsl:choose>
 		</xsl:variable>
 		<xsl:variable name="mixed-citation" select="exsl:node-set($rtf-mixed-citation)/node()"/>
+		<xsl:variable name="label">
+			<xsl:apply-templates select="label" mode="display-only-if-number"/>
+		</xsl:variable>
 		<li class="ref">
 			<a name="{@id}"/>
-			<xsl:if test="label">
-				<div class="label_citation"><xsl:value-of select="label"/><xsl:if test="not(contains(label,'.'))">.&#160; </xsl:if></div>
+			<xsl:if test="$label != ''">
+				<div class="label_citation"><xsl:value-of select="$label"/><xsl:if test="not(contains($label,'.'))">.&#160; </xsl:if></div>
 			</xsl:if>
 			<div class="citation">
 				<xsl:choose>

--- a/htdocs/xsl/pmc/v3.0/xml.css
+++ b/htdocs/xsl/pmc/v3.0/xml.css
@@ -240,3 +240,19 @@ padding-top: 0px;
     background-color: #DADFE5;
     width:60%;
  }
+.label_citation {
+    display: inline-block;
+}
+.citation {
+	padding-left: 5%;
+    display: inline-block;
+}
+.ref-list {
+	padding-left: 0;
+	list-style-type: none;
+}
+.ref-list li{
+ 	border-bottom: 1px dotted #ddd;
+ 	clear: both;
+ 	padding-bottom: 1em;
+}

--- a/htdocs/xsl/pmc/v3.0/xml.css
+++ b/htdocs/xsl/pmc/v3.0/xml.css
@@ -242,10 +242,12 @@ padding-top: 0px;
  }
 .label_citation {
     display: inline-block;
+    width: 5%;
 }
 .citation {
-	padding-left: 5%;
+	width: 90%;
     display: inline-block;
+    vertical-align: top;
 }
 .ref-list {
 	padding-left: 0;


### PR DESCRIPTION
Cuando el label esta dentro de mixed-citation, se presenta la información completa de mixed-citation, realice cambios para imprimir siempre el label aparte, para así poder tratar cada elemento de forma independiente y se pudiera notar una diferencia en la presentación de los datos, ya que la 

presentación del elemento único puede confundir y parecer que la información al principio esta duplicada.


Antes:
![t2a1](https://cloud.githubusercontent.com/assets/505143/11627843/b8d916e0-9cd4-11e5-8a2e-06d340496ba5.png)


Después:
![t2b1](https://cloud.githubusercontent.com/assets/505143/11627847/c209f2d4-9cd4-11e5-874f-3553f9c23929.png)


Antes:
![t02_a](https://cloud.githubusercontent.com/assets/505143/11627853/d206fdee-9cd4-11e5-8785-b863094961c6.png)

Después:
![t02_b](https://cloud.githubusercontent.com/assets/505143/11627901/20f135dc-9cd5-11e5-8bd3-33a6098514fd.png)

