### PR TITLE
Ajuste en licencias cuando v541 contiene versión

### DIFF
--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -3452,6 +3452,7 @@ fi
 		^c = codigo
 		^v = version
 	-->
+	<field action="replace" tag="4000"><pft>if instr(v4000^c,'/')>0 then '^l',v4000^l, '^s',v4000^s, '^c',left(v4000^c,instr(v4000^c,'/')-1), '^v',replace(v4000^c, left(v4000^c,instr(v4000^c,'/')), '') else v4000 fi</pft></field>
 	<field action="replace" tag="4000"><pft>replace(v4000,'BY','by')</pft></field>
 	<field action="replace" tag="4000"><pft>replace(v4000,'NC','nc')</pft></field>
 	<field action="replace" tag="4000"><pft>replace(v4000,'ND','nd')</pft></field>


### PR DESCRIPTION
Las licencias se mostraban de forma incorrecta, ya que se obtenía la versión de la licencia del sitio y no la de la licencia contenida en el campo v541, y a su vez el campo v541 contenía tanto licencia como versión.
Forma incorrecta:
![screen shot 2016-02-08 at 13 15 12](https://cloud.githubusercontent.com/assets/197827/12896140/0037938c-ce66-11e5-9e5f-a947d75d38d9.png)

Forma correcta:
![screen shot 2016-02-08 at 13 16 12](https://cloud.githubusercontent.com/assets/197827/12896154/1373c380-ce66-11e5-80d7-f51bf7c466b1.png)
