### PR TITLE
Ajustes na apresentação do texto da licença

### DIFF
--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -3446,40 +3446,6 @@ fi
 <return action="replace" tag="7047"><pft>v7047</pft></return>
 </function>
 
-<function name="getLicenseText" action="replace" tag="4000">
-	<!-- 
-		^l = lang
-		^s = site name
-		^c = codigo
-		^v = version
-	-->
-	<field action="replace" tag="4000"><pft>if instr(v4000^c,'/')>0 then '^l',v4000^l, '^s',v4000^s, '^c',left(v4000^c,instr(v4000^c,'/')-1), '^v',replace(v4000^c, left(v4000^c,instr(v4000^c,'/')), '') else v4000 fi</pft></field>
-	<field action="replace" tag="4000"><pft>replace(v4000,'BY','by')</pft></field>
-	<field action="replace" tag="4000"><pft>replace(v4000,'NC','nc')</pft></field>
-	<field action="replace" tag="4000"><pft>replace(v4000,'ND','nd')</pft></field>
-	<field action="replace" tag="4000"><pft>replace(v4000,'SA','sa')</pft></field>
-
-	<flow action="jump"><pft>if v4000^c='nd' then 'nd' else v4000^l fi</pft></flow>
-
-	<label>nd</label>
-	<field action="replace" tag="540"><pft>'<!-- nd -->'</pft></field>
-	<flow action="jump">end</flow>
-
-	<label>pt</label>
-	<field action="replace" tag="540"><pft>'<a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/deed.pt"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/',v4000^c,'/',v4000^v,'/80x15.png"/></a> Todo o conteúdo deste site ',v4000^s,', exceto quando identificado, utiliza  uma <a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/deed.pt">Licença de Atribuição Creative Commons</a>.'</pft></field>
-	<flow action="jump"><pft>if p(v540) then 'end' else 'en' fi</pft></flow>
-	
-	<label>es</label>
-	<field action="replace" tag="540"><pft>'<a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/deed.es"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/',v4000^c,'/',v4000^v,'/80x15.png"/></a> Todo el contenido de este sitio ',v4000^s,', excepto dónde está identificado, está bajo una <a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/deed.es">Licencia de Atribución Creative Commons</a>.'</pft></field>
-	<flow action="jump"><pft>if p(v540) then 'end' fi</pft></flow>
-
-	<label>en</label>
-	<field action="replace" tag="540"><pft>'<a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/',v4000^c,'/',v4000^v,'/80x15.png"/></a> All the contents of this site ',v4000^s,', except where otherwise noted, is licensed under a <a rel="license" href="http://creativecommons.org/licenses/',v4000^c,'/',v4000^v,'/">Creative Commons Attribution License</a>.'</pft></field>
-
-	<label>end</label>
-	<return action="replace" tag="9540"><pft>v540</pft></return>
-</function>
-
 <function name="getCreativeCommonsInfo" action="replace" tag="4000">
 	<!-- ^llang'^f',lang,'_',page name,|^p|pid da pagina,'^s',site name,^c codigo licenca ^v version-->
 	<field action="replace" tag="4000"><pft>if a(v4000^v) then v4000,'^v4.0' fi</pft></field>
@@ -3499,47 +3465,77 @@ fi
 	<label>issue</label>
 	<field action="replace" tag="1">issue</field>
 	<field action="replace" tag="541"><pft>ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),v541)</pft></field>
-	<call name="getLicenseText"><pft>if p(v541) then '^l',v4000^l,'^s',v4000^s,'^c',v541,'^v',v4000^v, fi</pft></call>
-	<field action="replace" tag="540" split="occ"><pft>if a(v9540) then ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),(v540/)) fi</pft></field>
-	<field action="replace" tag="9540"><pft>if p(v540) then (if v540^l=v4000^l[1] then v540^t fi) fi</pft></field>
-	<flow action="jump"><pft>if p(v9540) then 'license' fi</pft></flow>
+	<!-- se ausente v541, tentar o v540 que contém texto/html -->
+	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540:'</p>' then 'nd',break, fi fi)) fi</pft></field>
+	<flow action="jump"><pft>if p(v541) or p(v540) then 'license' fi</pft></flow>
 	
 	<label>journal</label>
 	<field action="replace" tag="1">journal</field>
 	<field action="replace" tag="541"><pft>ref(['TITLE']l(['TITLE'],'LOC=',v8801),v541)</pft></field>
-	<call name="getLicenseText"><pft>if p(v541) then '^l',v4000^l,'^s',v4000^s,'^c',v541,'^v',v4000^v, fi</pft></call>
-	<field action="replace" tag="540" split="occ"><pft>if a(v9540) then ref(['TITLE']l(['TITLE'],'LOC=',v8801),(v540/)) fi</pft></field>
-	<flow action="jump"><pft>if p(v9540) then 'license' fi</pft></flow>
+	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['TITLE']l(['TITLE'],'LOC=',v8801),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540:'</p>' then 'nd',break, fi, fi)) fi</pft></field>
+	<flow action="jump"><pft>if p(v541) or p(v540) then 'license' fi</pft></flow>
 	
 	<label>site</label>
 	<field action="replace" tag="1">site</field>
 	<field action="replace" tag="541"><pft>v4000^c</pft></field>
-	<call name="getLicenseText"><pft>if p(v4000^c) then '^l',v4000^l,'^s',v4000^s,'^c',v4000^c,'^v',v4000^v, fi</pft></call>
-	<flow action="jump"><pft>if p(v9540) then 'license' fi</pft></flow>
+	<flow action="jump"><pft>if p(v541) or p(v540) then 'license' fi</pft></flow>
 	
 	<label>other</label>
-	<field action="replace" tag="1">none</field>
+	<field action="replace" tag="1">site</field>
 	<call name="existeFile"><pft>'^p../bases/license/^f',v4000^l,'_general.txt'</pft></call>
-	<flow action="jump"><pft>if a(v7999) then 'end' fi</pft></flow>
+	<flow action="jump"><pft>if a(v7999) then 'license' fi</pft></flow>
 
-	<field action="replace" tag="1">general</field>
 	<do task="import">
 	    <parm name="file"><pft>'../bases/license/',v4000^l,'_general.txt'</pft></parm>
 		<parm name="type">RLine</parm>
     	<loop>
-			<field action="import" tag="list">9540</field>
-			<field action="add" tag="9540"><pft>v1,"|"v2,"|"v3,"|"v4,"|"v5,"|"v6,"|"v7,"|"v8,"|"v9/</pft></field>
-			<field action="export" tag="list">9540</field>
+			<field action="import" tag="list">540</field>
+			<field action="add" tag="540"><pft>v1,"|"v2,"|"v3,"|"v4,"|"v5,"|"v6,"|"v7,"|"v8,"|"v9/</pft></field>
+			<field action="export" tag="list">540</field>
    		</loop>
-		<field action="replace" tag="9540"><pft>(v9540/)</pft></field>
+		<field action="replace" tag="540"><pft>(v540/)</pft></field>
 	</do>
 	
 	<label>license</label>
+	<field action="replace" tag="540">
+		<pft>
+			,if instr(v540,':/creativecommons.org/licenses/')>0 then
+				mid(v540,instr(v540,':/creativecommons.org/licenses/')+size(':/creativecommons.org/licenses/'),size(v540))
+			,fi
+		</pft>
+	</field>
+	<field action="replace" tag="541">
+		<pft>
+			,if v540:'/deed' then
+				,mid(v540,1,instr(v540,'/deed'))
+			,else
+				,if v540:'/"' then
+			 		,mid(v540,1,instr(v540,'/"')),
+				,else
+					v540
+				,fi
+			,fi
+		</pft>
+	</field>
+	<field action="replace" tag="541"><pft>replace(v541,'BY','by')</pft></field>
+	<field action="replace" tag="541"><pft>replace(v541,'NC','nc')</pft></field>
+	<field action="replace" tag="541"><pft>replace(v541,'ND','nd')</pft></field>
+	<field action="replace" tag="541"><pft>replace(v541,'SA','sa')</pft></field>
+	<field action="replace" tag="541"><pft>replace(v541,'IGO','igo')</pft></field>
+	<field action="replace" tag="541"><pft>v541,if v541<>'nd' and v541<>'' and not v541:'/' and not v541:'igo' then '/',v4000^v fi</pft></field>
 	<display>
 		<pft>
 			'<PERMISSIONS source="',v1,'">'/
 			'<permissions>'/
-			'<license license-type="',v541,if a(v541) then 'open-access' fi,'"><p>',v9540,'</p></license>'
+			,if v541='nd' then
+				'<!-- no license Creative Commons -->'
+			,else
+				,if v541<>'' then
+					'<license license-type="open-access" href="http://creativecommons.org/licenses/',v541,'"></license>'
+				,else
+					'<!-- no license found -->'
+				,fi
+			,fi
 			'</permissions>'/
 			'</PERMISSIONS>'/
 		</pft>

--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -3466,13 +3466,13 @@ fi
 	<field action="replace" tag="1">issue</field>
 	<field action="replace" tag="541"><pft>ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),v541)</pft></field>
 	<!-- se ausente v541, tentar o v540 que contém texto/html -->
-	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540:'</p>' then 'nd',break, fi fi)) fi</pft></field>
+	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['NEWISSUE']l(['NEWISSUE'],'Y',v8802),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540<>'' then 'nd',break, fi fi)) fi</pft></field>
 	<flow action="jump"><pft>if p(v541) or p(v540) then 'license' fi</pft></flow>
 	
 	<label>journal</label>
 	<field action="replace" tag="1">journal</field>
 	<field action="replace" tag="541"><pft>ref(['TITLE']l(['TITLE'],'LOC=',v8801),v541)</pft></field>
-	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['TITLE']l(['TITLE'],'LOC=',v8801),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540:'</p>' then 'nd',break, fi, fi)) fi</pft></field>
+	<field action="replace" tag="540" split="occ"><pft>if a(v541) then ref(['TITLE']l(['TITLE'],'LOC=',v8801),(if v540:':/creativecommons.org/licenses/' then v540,break, else if v540<>'' then 'nd',break, fi, fi)) fi</pft></field>
 	<flow action="jump"><pft>if p(v541) or p(v540) then 'license' fi</pft></flow>
 	
 	<label>site</label>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -11,8 +11,8 @@
 	
 	<xsl:template match="article-meta/permissions | PERMISSIONS[@source]/permissions">
 		<xsl:apply-templates select="." mode="permissions-footnote">
-			<xsl:with-param name="style">article-license</xsl:with-param>
-			<xsl:with-param name="text_lang" select="$langtext"/>
+			<xsl:with-param name="text_lang" select="$TEXT_LANG"/>
+			<xsl:with-param name="interface_lang" select="$interfaceLang"/>
 		</xsl:apply-templates>
 	</xsl:template>
 	

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -10,10 +10,7 @@
 	<xsl:variable name="affiliations" select="$original//aff"/>
 	
 	<xsl:template match="article-meta/permissions | PERMISSIONS[@source]/permissions">
-		<xsl:apply-templates select="." mode="permissions-footnote">
-			<xsl:with-param name="text_lang" select="$TEXT_LANG"/>
-			<xsl:with-param name="interface_lang" select="$interfaceLang"/>
-		</xsl:apply-templates>
+		<xsl:apply-templates select="." mode="permissions-disclaimer"/>
 	</xsl:template>
 	
 	<xsl:template match="*" mode="id">

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -9,7 +9,7 @@
 	<xsl:variable name="use_original_aff" select="count($original//institution[@content-type='original'])&gt;0"/>
 	<xsl:variable name="affiliations" select="$original//aff"/>
 	
-	<xsl:template match="article-meta/permissions | PERMISSIONS[@source]/permissions">
+	<xsl:template match="article-meta/permissions | PERMISSIONS[@source]/permissions | body//*/permissions">
 		<xsl:apply-templates select="." mode="permissions-disclaimer"/>
 	</xsl:template>
 	
@@ -695,12 +695,11 @@
 			</xsl:choose>
 		</div>
 	</xsl:template>
-	
 	<xsl:template match="fig" mode="scift-standard">
 		<div class="figure">
 			<xsl:call-template name="named-anchor"/>
 			<xsl:apply-templates select="graphic|media"/>
-			<xsl:apply-templates select="attrib"/>
+			<xsl:apply-templates select="." mode="object-properties"/>
 			<p class="label_caption">
 				<xsl:apply-templates select="label | caption" mode="scift-label-caption-graphic"/>
 			</p>
@@ -732,7 +731,7 @@
 
 			</p>
 			<xsl:apply-templates select="graphic | table | table-wrap-foot"/>
-			
+			<xsl:apply-templates select="." mode="object-properties"/>
 		</div>
 	</xsl:template>
 	<xsl:template match="table-wrap-foot">
@@ -1620,4 +1619,12 @@
 	<xsl:template match="attrib">
 		<xsl:apply-templates select="*|text()"></xsl:apply-templates>
 	</xsl:template>
+	
+	<xsl:template match="fig" mode="object-properties">
+		<xsl:apply-templates select="attrib | permissions"/>
+	</xsl:template>
+	<xsl:template match="table-wrap | table-wrap//*[permissions]" mode="object-properties">
+		<xsl:apply-templates select="permissions"/>
+	</xsl:template>
+	
 </xsl:stylesheet>

--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -1151,19 +1151,25 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
                     <xsl:otherwise>All the contents of this article, except where otherwise noted, is licensed under a </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
-            <xsl:when test="$object='site' or $object=''">
+            <xsl:when test="$object='site'">
                 <xsl:choose>
-                    <xsl:when test="$lang='es'">Todo el contenido de este sitio, excepto dónde está identificado, está bajo una </xsl:when>
-                    <xsl:when test="$lang='pt'">Todo o conteúdo deste Website, exceto onde está identificado, está licenciado sob uma </xsl:when>
-                    <xsl:otherwise>All the contents of this Website, except where otherwise noted, is licensed under a </xsl:otherwise>
+                    <xsl:when test="$control_info/SCIELO_INFO/SERVER!=''">
+                        <xsl:choose>
+                            <xsl:when test="$lang='es'">Todo el contenido de <xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/>, excepto dónde está identificado, está bajo una </xsl:when>
+                            <xsl:when test="$lang='pt'">Todo o conteúdo de <xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/>, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                            <xsl:otherwise>All the contents of <xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/>, except where otherwise noted, is licensed under a </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:choose>
+                            <xsl:when test="$lang='es'">Todo el contenido de este sitio, excepto dónde está identificado, está bajo una </xsl:when>
+                            <xsl:when test="$lang='pt'">Todo o conteúdo deste Website, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                            <xsl:otherwise>All the contents of this Website, except where otherwise noted, is licensed under a </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:choose>
-                    <xsl:when test="$lang='es'">Todo el contenido de <xsl:value-of select="$object"/>, excepto dónde está identificado, está bajo una </xsl:when>
-                    <xsl:when test="$lang='pt'">Todo o conteúdo de <xsl:value-of select="$object"/>, exceto onde está identificado, está licenciado sob uma </xsl:when>
-                    <xsl:otherwise>All the contents of <xsl:value-of select="$object"/>, except where otherwise noted, is licensed under a </xsl:otherwise>
-                </xsl:choose>
             </xsl:otherwise>            
         </xsl:choose>
         
@@ -1177,10 +1183,20 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
     </xsl:template>
     
     <xsl:template match="permissions" mode="permissions-disclaimer">
-        <xsl:param name="object"><xsl:choose>
-            <xsl:when test="../@source='site' and $control_info/SCIELO_INFO/SERVER!=''"><xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="../@source"/></xsl:otherwise>
-        </xsl:choose></xsl:param>
+        <xsl:variable name="object"><xsl:choose>
+            <xsl:when test="../@source"><xsl:value-of select="../@source"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="name(../node())"/></xsl:otherwise>
+        </xsl:choose></xsl:variable>
+        
+        <xsl:if test="copyright-statement or (copyright-year and copyright-holder)">
+            <div class="copyright">
+                <xsl:apply-templates select="copyright-statement" mode="permissions-disclaimer"/>
+                <xsl:if test="not(copyright-statement) and copyright-holder and copyright-holder">
+                    <xsl:apply-templates select="copyright-year" mode="permissions-disclaimer"/>
+                    <xsl:apply-templates select="copyright-holder" mode="permissions-disclaimer"/>
+                </xsl:if>
+            </div>
+        </xsl:if>
         <div class="license">
             <xsl:choose>
                 <xsl:when test="license[@xml:lang=$articleLang]">
@@ -1203,7 +1219,7 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:apply-templates select="license[1]" mode="permissions-disclaimer">
-                        <xsl:with-param name="lang" select="$interface_lang"/>
+                        <xsl:with-param name="lang" select="$interfaceLang"/>
                         <xsl:with-param name="object" select="$object"/>
                     </xsl:apply-templates>
                 </xsl:otherwise>
@@ -1217,6 +1233,8 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
         <xsl:variable name="license_href"><xsl:choose>
             <xsl:when test="contains(@xlink:href,'://creativecommons.org/licenses/')"><xsl:value-of select="@xlink:href"/></xsl:when>
             <xsl:when test="contains(@href,'://creativecommons.org/licenses/')"><xsl:value-of select="@href"/></xsl:when>
+            <xsl:when test="@href"><xsl:value-of select="@href"/></xsl:when>
+            <xsl:when test="@xlink:href"><xsl:value-of select="@xlink:href"/></xsl:when>
             <xsl:otherwise>invalid</xsl:otherwise>
         </xsl:choose></xsl:variable>
         <xsl:if test="$license_href='invalid'">
@@ -1233,9 +1251,10 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
             <xsl:variable name="license_img_src"><xsl:choose>
                 <xsl:when test=".//graphic/@xlink:href"><xsl:value-of select=".//graphic/@xlink:href"/></xsl:when>
                 <xsl:when test=".//img/@src"><xsl:value-of select=".//img/@src"/></xsl:when>
-                <xsl:otherwise>http://i.creativecommons.org/l<xsl:value-of select="substring-after($main_license_href,'licenses')"/>/80x15.png</xsl:otherwise>
+                <xsl:when test="contains($license_href,'://creativecommons.org/licenses/')">http://i.creativecommons.org/l<xsl:value-of select="substring-after($main_license_href,'licenses')"/>/80x15.png</xsl:when>
+                <xsl:otherwise></xsl:otherwise>
             </xsl:choose></xsl:variable>
-            <xsl:variable name="license_href_with_lang"><xsl:value-of select="$main_license_href"/><xsl:if test="$lang!='' and $main_license_href!=''">/deed.<xsl:value-of select="$lang"/></xsl:if></xsl:variable>
+            <xsl:variable name="license_href_with_lang"><xsl:value-of select="$main_license_href"/><xsl:if test="$lang!='' and contains($main_license_href,'://creativecommons.org/licenses/')">/deed.<xsl:value-of select="$lang"/></xsl:if></xsl:variable>
             <xsl:if test="$license_href_with_lang!=''">
                 <p>
                     <xsl:if test="$license_img_src!=''">
@@ -1245,12 +1264,12 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
                         <xsl:text>&#160;</xsl:text>
                     </xsl:if>
                     <xsl:choose>
-                        <xsl:when test="license-p[not(.//a)]">
+                        <xsl:when test="license-p[not(.//a)] and $license_img_src=''">
                             <a rel="license" href="{$license_href_with_lang}">
                                 <xsl:apply-templates select="license-p" mode="license-disclaimer"/>
                             </a>
                         </xsl:when>
-                        <xsl:when test="license-p[.//a]">
+                        <xsl:when test="license-p">
                             <xsl:apply-templates select="license-p" mode="license-disclaimer"/>
                         </xsl:when>
                         <xsl:otherwise>

--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -1124,98 +1124,155 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
     <xsl:template match="PERMISSIONS[@source='site']/permissions">
         <div class="license">
-            <xsl:copy-of select=".//license/p"/>    
+            <xsl:apply-templates select="." mode="permissions-footnote">
+                <xsl:with-param name="interface_lang" select="$interfaceLang"/>
+                <xsl:with-param name="object" select="$control_info/SCIELO_INFO/SERVER"/>
+            </xsl:apply-templates>
         </div>
     </xsl:template>
     <xsl:template match="PERMISSIONS[@source!='site']/permissions">
         <xsl:apply-templates select="." mode="permissions-footnote">
-            <xsl:with-param name="style">license</xsl:with-param>
-            <xsl:with-param name="t" select="$interfaceLang"/>
+            <xsl:with-param name="interface_lang" select="$interfaceLang"/>
+            <xsl:with-param name="object" select="../@source"/>
         </xsl:apply-templates>
     </xsl:template>
-    
     <xsl:template match="*" mode="license-disclaimer">
-        <xsl:param name="text_lang"/>
-        <xsl:param name="translated_license_href"/>
-        
+        <xsl:param name="lang"/>
+        <xsl:param name="license_href_with_lang"/>
+        <xsl:param name="object"/>
+        <xsl:comment><xsl:value-of select="$object"/></xsl:comment>
         <xsl:choose>
-            <xsl:when test="$text_lang='es'">Todo el contenido de esta revista, excepto dónde está identificado, está bajo una </xsl:when>
-            <xsl:when test="$text_lang='pt'">Todo o conteúdo deste periódico, exceto onde está identificado, está licenciado sob uma </xsl:when>
-            <xsl:otherwise>All the contents of this journal, except where otherwise noted, is licensed under a </xsl:otherwise>
+            <xsl:when test="$object='journal' or $object='issue'">
+                <xsl:choose>
+                    <xsl:when test="$lang='es'">Todo el contenido de esta revista, excepto dónde está identificado, está bajo una </xsl:when>
+                    <xsl:when test="$lang='pt'">Todo o conteúdo deste periódico, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                    <xsl:otherwise>All the contents of this journal, except where otherwise noted, is licensed under a </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:when test="$object='article'">
+                <xsl:choose>
+                    <xsl:when test="$lang='es'">Todo el contenido de este artículo, excepto dónde está identificado, está bajo una </xsl:when>
+                    <xsl:when test="$lang='pt'">Todo o conteúdo deste artigo, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                    <xsl:otherwise>All the contents of this article, except where otherwise noted, is licensed under a </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:when test="$object='site' or $object=''">
+                <xsl:choose>
+                    <xsl:when test="$lang='es'">Todo el contenido de este sitio, excepto dónde está identificado, está bajo una </xsl:when>
+                    <xsl:when test="$lang='pt'">Todo o conteúdo deste Website, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                    <xsl:otherwise>All the contents of this Website, except where otherwise noted, is licensed under a </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="$lang='es'">Todo el contenido de <xsl:value-of select="$object"/>, excepto dónde está identificado, está bajo una </xsl:when>
+                    <xsl:when test="$lang='pt'">Todo o conteúdo de <xsl:value-of select="$object"/>, exceto onde está identificado, está licenciado sob uma </xsl:when>
+                    <xsl:otherwise>All the contents of <xsl:value-of select="$object"/>, except where otherwise noted, is licensed under a </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>            
         </xsl:choose>
-        <a href="{$translated_license_href}">
+        
+        <a href="{$license_href_with_lang}">
             <xsl:choose>
-                <xsl:when test="$text_lang='es'">Licencia Creative Commons</xsl:when>
-                <xsl:when test="$text_lang='pt'">Licença Creative Commons</xsl:when>
+                <xsl:when test="$lang='es'">Licencia Creative Commons</xsl:when>
+                <xsl:when test="$lang='pt'">Licença Creative Commons</xsl:when>
                 <xsl:otherwise>Creative Commons Attribution License</xsl:otherwise>
             </xsl:choose>
         </a>
     </xsl:template>
     
-    <xsl:template match="*" mode="permissions-footnote">
-        <xsl:param name="style"/>
+    <xsl:template match="permissions" mode="permissions-footnote">
+        <xsl:param name="interface_lang"/>
         <xsl:param name="text_lang"/>
-        
-        <div class="{$style}">
-            <xsl:variable name="license_href"><xsl:choose>
-                <xsl:when test="contains(.//license/@href,'://creativecommons.org/licenses/')"><xsl:value-of select=".//license/@href"/></xsl:when>
-                <xsl:when test="contains(.//license/@xlink:href,'://creativecommons.org/licenses/')"><xsl:value-of select=".//license/@xlink:href"/></xsl:when>
-                <xsl:when test="contains(.//license//a/@href,'://creativecommons.org/licenses/')"><xsl:value-of select=".//license//a/@href"/></xsl:when>
-                <xsl:otherwise>invalid</xsl:otherwise>
-            </xsl:choose></xsl:variable>
+        <xsl:param name="object"/>
+        <div class="license">
             <xsl:choose>
-                <xsl:when test="$license_href='invalid'">
-                    <xsl:comment>url de license eh invalida</xsl:comment>
-                    <xsl:comment><xsl:value-of select=".//license/@href"/></xsl:comment>
-                    <xsl:comment><xsl:value-of select=".//license/@xlink:href"/></xsl:comment>
-                    <xsl:comment><xsl:value-of select=".//license//a/@href"/></xsl:comment>
+                <xsl:when test="license[@xml:lang=$text_lang]">
+                    <xsl:apply-templates select="license[@xml:lang=$text_lang]" mode="permissions-footnote">
+                        <xsl:with-param name="lang" select="$text_lang"/>
+                        <xsl:with-param name="object" select="$object"/>
+                    </xsl:apply-templates>
+                </xsl:when>
+                <xsl:when test="license[@xml:lang=$interface_lang]">
+                    <xsl:apply-templates select="license[@xml:lang=$interface_lang]" mode="permissions-footnote">
+                        <xsl:with-param name="lang" select="$interface_lang"/>
+                        <xsl:with-param name="object" select="$object"/>
+                    </xsl:apply-templates>
+                </xsl:when>
+                <xsl:when test="license[@xml:lang='en']">
+                    <xsl:apply-templates select="license[@xml:lang='en']" mode="permissions-footnote">
+                        <xsl:with-param name="lang" select="'en'"/>
+                        <xsl:with-param name="object" select="$object"/>
+                    </xsl:apply-templates>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:variable name="main_license_href"><xsl:choose><xsl:when test="contains($license_href,'/deed')"><xsl:value-of select="substring-before($license_href,'/deed')"/></xsl:when>
-                        <xsl:when test="substring($license_href,string-length($license_href))='/'"><xsl:value-of select="substring($license_href,1,string-length($license_href)-1)"/></xsl:when>
-                        <xsl:otherwise><xsl:value-of select="$license_href"/></xsl:otherwise>
-                    </xsl:choose></xsl:variable>
-                    <xsl:variable name="license_img_src"><xsl:choose>
-                        <xsl:when test=".//graphic/@xlink:href"><xsl:value-of select=".//graphic/@xlink:href"/></xsl:when>
-                        <xsl:when test=".//img/@src"><xsl:value-of select=".//img/@src"/></xsl:when>
-                        <xsl:otherwise>http://i.creativecommons.org/l<xsl:value-of select="substring-after($main_license_href,'licenses')"/>/88x31.png</xsl:otherwise>
-                    </xsl:choose></xsl:variable>
-                    <xsl:variable name="translated_license_href"><xsl:value-of select="$main_license_href"/><xsl:if test="$text_lang!='' and $main_license_href!=''">/deed.<xsl:value-of select="$text_lang"/></xsl:if></xsl:variable>
-                    <xsl:choose>
-                        <xsl:when test="$translated_license_href!=''">
-                            <p>
-                                <xsl:choose>
-                                    <xsl:when test="contains($license_img_src, '88x31')">
-                                        <a rel="license" href="{$translated_license_href}">
-                                            <img src="{$license_img_src}" alt="Creative Commons License" style="border-width:0"/>
-                                        </a>
-                                    </xsl:when>
-                                    <xsl:when test="$license_img_src!=''">
-                                        <a rel="license" href="{$translated_license_href}">
-                                            <img src="{$license_img_src}" alt="Creative Commons License" style="border-width:0"/>
-                                        </a>
-                                        <xsl:text>&#160;</xsl:text>
-                                        <xsl:apply-templates select="." mode="license-disclaimer">
-                                            <xsl:with-param name="translated_license_href" select="$translated_license_href"/>
-                                            <xsl:with-param name="text_lang" select="$text_lang"/>
-                                            
-                                        </xsl:apply-templates>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:apply-templates select="." mode="license-disclaimer">
-                                            <xsl:with-param name="translated_license_href" select="$translated_license_href"/>
-                                            <xsl:with-param name="text_lang" select="$text_lang"/></xsl:apply-templates>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </p> 
-                        </xsl:when>
-                    </xsl:choose>
+                    <xsl:apply-templates select="license[1]" mode="permissions-footnote">
+                        <xsl:with-param name="lang" select="$interface_lang"/>
+                        <xsl:with-param name="object" select="$object"/>
+                    </xsl:apply-templates>
                 </xsl:otherwise>
             </xsl:choose>
         </div>
+    </xsl:template>
+    
+    <xsl:template match="permissions/license" mode="permissions-footnote">
+        <xsl:param name="lang"/>
+        <xsl:param name="object"/>
+        <xsl:variable name="license_href"><xsl:choose>
+            <xsl:when test="contains(@xlink:href,'://creativecommons.org/licenses/')"><xsl:value-of select="@xlink:href"/></xsl:when>
+            <xsl:when test="contains(@href,'://creativecommons.org/licenses/')"><xsl:value-of select="@href"/></xsl:when>
+            <xsl:otherwise>invalid</xsl:otherwise>
+        </xsl:choose></xsl:variable>
+        <xsl:if test="$license_href='invalid'">
+            <xsl:comment>url de license eh invalida</xsl:comment>
+            <xsl:comment><xsl:value-of select="@xlink:href"/></xsl:comment>
+            <xsl:comment><xsl:value-of select="@href"/></xsl:comment>
+        </xsl:if>
+        
+        <xsl:if test="$license_href!='invalid'">
+            <xsl:variable name="main_license_href"><xsl:choose><xsl:when test="contains($license_href,'/deed')"><xsl:value-of select="substring-before($license_href,'/deed')"/></xsl:when>
+                <xsl:when test="substring($license_href,string-length($license_href))='/'"><xsl:value-of select="substring($license_href,1,string-length($license_href)-1)"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="$license_href"/></xsl:otherwise>
+            </xsl:choose></xsl:variable>
+            <xsl:variable name="license_img_src"><xsl:choose>
+                <xsl:when test=".//graphic/@xlink:href"><xsl:value-of select=".//graphic/@xlink:href"/></xsl:when>
+                <xsl:when test=".//img/@src"><xsl:value-of select=".//img/@src"/></xsl:when>
+                <xsl:otherwise>http://i.creativecommons.org/l<xsl:value-of select="substring-after($main_license_href,'licenses')"/>/80x15.png</xsl:otherwise>
+            </xsl:choose></xsl:variable>
+            <xsl:variable name="license_href_with_lang"><xsl:value-of select="$main_license_href"/><xsl:if test="$lang!='' and $main_license_href!=''">/deed.<xsl:value-of select="$lang"/></xsl:if></xsl:variable>
+            <xsl:if test="$license_href_with_lang!=''">
+                <p>
+                    <xsl:if test="$license_img_src!=''">
+                        <a rel="license" href="{$license_href_with_lang}">
+                            <img src="{$license_img_src}" alt="Creative Commons License" style="border-width:0"/>
+                        </a>
+                        <xsl:text>&#160;</xsl:text>
+                    </xsl:if>
+                    <xsl:choose>
+                        <xsl:when test="license-p[not(.//a)]">
+                            <a rel="license" href="{$license_href_with_lang}">
+                                <xsl:apply-templates select="license-p" mode="license-disclaimer"/>
+                            </a>
+                        </xsl:when>
+                        <xsl:when test="license-p[.//a]">
+                            <xsl:apply-templates select="license-p" mode="license-disclaimer"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:apply-templates select="." mode="license-disclaimer">
+                                <xsl:with-param name="license_href_with_lang" select="$license_href_with_lang"/>
+                                <xsl:with-param name="lang" select="$lang"/>
+                                <xsl:with-param name="object" select="$object"/>
+                            </xsl:apply-templates>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </p> 
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="license-p" mode="license-disclaimer">
+        <xsl:apply-templates select="*|text()"/>
     </xsl:template>
     <xsl:template match="*" mode="footer-journal">
         <xsl:choose>

--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -5,6 +5,8 @@
     <xsl:variable name="HOME_URL">http://<xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/>
         <xsl:value-of select="$control_info/SCIELO_INFO/PATH_DATA"/>scielo.php</xsl:variable>
     <xsl:variable name="interfaceLang" select="$control_info/LANGUAGE"/>
+    <xsl:variable name="articleLang" select="//ARTICLE/@TEXTLANG"/>
+
     <xsl:variable name="SITE_NAME" select="$control_info/SITE_NAME"/>
     <xsl:variable name="translations"
         select="document(concat('../xml/',$interfaceLang,'/translation.xml'))/translations"/>
@@ -1124,20 +1126,11 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    <xsl:template match="PERMISSIONS[@source='site']/permissions">
-        <div class="license">
-            <xsl:apply-templates select="." mode="permissions-footnote">
-                <xsl:with-param name="interface_lang" select="$interfaceLang"/>
-                <xsl:with-param name="object" select="$control_info/SCIELO_INFO/SERVER"/>
-            </xsl:apply-templates>
-        </div>
+
+    <xsl:template match="PERMISSIONS/permissions">
+        <xsl:apply-templates select="." mode="permissions-disclaimer"/>
     </xsl:template>
-    <xsl:template match="PERMISSIONS[@source!='site']/permissions">
-        <xsl:apply-templates select="." mode="permissions-footnote">
-            <xsl:with-param name="interface_lang" select="$interfaceLang"/>
-            <xsl:with-param name="object" select="../@source"/>
-        </xsl:apply-templates>
-    </xsl:template>
+    
     <xsl:template match="*" mode="license-disclaimer">
         <xsl:param name="lang"/>
         <xsl:param name="license_href_with_lang"/>
@@ -1183,32 +1176,33 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
         </a>
     </xsl:template>
     
-    <xsl:template match="permissions" mode="permissions-footnote">
-        <xsl:param name="interface_lang"/>
-        <xsl:param name="text_lang"/>
-        <xsl:param name="object"/>
+    <xsl:template match="permissions" mode="permissions-disclaimer">
+        <xsl:param name="object"><xsl:choose>
+            <xsl:when test="../@source='site' and $control_info/SCIELO_INFO/SERVER!=''"><xsl:value-of select="$control_info/SCIELO_INFO/SERVER"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="../@source"/></xsl:otherwise>
+        </xsl:choose></xsl:param>
         <div class="license">
             <xsl:choose>
-                <xsl:when test="license[@xml:lang=$text_lang]">
-                    <xsl:apply-templates select="license[@xml:lang=$text_lang]" mode="permissions-footnote">
-                        <xsl:with-param name="lang" select="$text_lang"/>
+                <xsl:when test="license[@xml:lang=$articleLang]">
+                    <xsl:apply-templates select="license[@xml:lang=$articleLang]" mode="permissions-disclaimer">
+                        <xsl:with-param name="lang" select="$articleLang"/>
                         <xsl:with-param name="object" select="$object"/>
                     </xsl:apply-templates>
                 </xsl:when>
-                <xsl:when test="license[@xml:lang=$interface_lang]">
-                    <xsl:apply-templates select="license[@xml:lang=$interface_lang]" mode="permissions-footnote">
-                        <xsl:with-param name="lang" select="$interface_lang"/>
+                <xsl:when test="license[@xml:lang=$interfaceLang]">
+                    <xsl:apply-templates select="license[@xml:lang=$interfaceLang]" mode="permissions-disclaimer">
+                        <xsl:with-param name="lang" select="$interfaceLang"/>
                         <xsl:with-param name="object" select="$object"/>
                     </xsl:apply-templates>
                 </xsl:when>
                 <xsl:when test="license[@xml:lang='en']">
-                    <xsl:apply-templates select="license[@xml:lang='en']" mode="permissions-footnote">
+                    <xsl:apply-templates select="license[@xml:lang='en']" mode="permissions-disclaimer">
                         <xsl:with-param name="lang" select="'en'"/>
                         <xsl:with-param name="object" select="$object"/>
                     </xsl:apply-templates>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:apply-templates select="license[1]" mode="permissions-footnote">
+                    <xsl:apply-templates select="license[1]" mode="permissions-disclaimer">
                         <xsl:with-param name="lang" select="$interface_lang"/>
                         <xsl:with-param name="object" select="$object"/>
                     </xsl:apply-templates>
@@ -1217,7 +1211,7 @@ tem esses dois templates "vazios" para nao aparecer o conteudo nos rodapes . . .
         </div>
     </xsl:template>
     
-    <xsl:template match="permissions/license" mode="permissions-footnote">
+    <xsl:template match="permissions/license" mode="permissions-disclaimer">
         <xsl:param name="lang"/>
         <xsl:param name="object"/>
         <xsl:variable name="license_href"><xsl:choose>


### PR DESCRIPTION
A partir da SPS 1.4 será permitido mais de 1 texto de licença, sendo que cada texto está associado a um idioma. O texto de licença a ser apresentado no rodapé deve ser no idioma do texto do artigo, ou no idioma da interface, ou em inglês, ou o texto de licença que está identificado, não importando o idioma, nesta ordem.

Em consequência de #395, o #386 é também feito. Atualmente é apresentado a imagem correspondente ao tipo de licença. No lugar da imagem ficará o texto no idioma correspondente.

Fixes #395 
Fixes #386