### PR TITLE
[560] Corrige a montagem do link para o PDF quando o link deve aparec…

### DIFF
--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -167,8 +167,13 @@
         <xsl:param name="page"/>
         <xsl:choose>
             <xsl:when test="$script = 'sci_pdf' ">
+                <xsl:variable name="location"><xsl:choose>
+                    <xsl:when test="//ARTICLE[@PID=$seq]"><xsl:value-of select="//ARTICLE[@PID=$seq]/LANGUAGES/PDF_LANGS/LANG[.=$txtlang]/@TRANSLATION"/></xsl:when>
+                    <xsl:when test="//ARTICLE/LANGUAGES/PDF_LANGS/LANG"><xsl:value-of select="//ARTICLE[@PID=$seq]/LANGUAGES/PDF_LANGS/LANG[.=$txtlang]/@TRANSLATION"/></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="$article/LANGUAGES/PDF_LANGS/LANG[.=$txtlang]/@TRANSLATION"/></xsl:otherwise>
+                </xsl:choose></xsl:variable>
                 <xsl:attribute name="href">
-                    <xsl:value-of select="$control_info/SCIELO_INFO/PATH_DATA"/>pdf/<xsl:value-of select="//ARTICLE[@PID=$seq]/LANGUAGES/PDF_LANGS/LANG[.=$txtlang]/@TRANSLATION"/>
+                    <xsl:value-of select="$control_info/SCIELO_INFO/PATH_DATA"/>pdf/<xsl:value-of select="$location"/>
                 </xsl:attribute>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
…er dentro do texto completo e o texto vem do XML.

Fixes #560 


A XSL, no template AddScieloLink estava considerando somente o XML da página e não o XML do artigo. No XML do artigo não existe ARTICLE. Para ter acesso aos dados do XML da página foi necessário usar a variável $article.