### PR TITLE
Corrige link para notas al pie

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -851,7 +851,7 @@
 	
 	<xsl:template match="table//xref">
 		<xsl:if test="@ref-type='fn'">
-			<a name="back_{@rid}"/>
+			<a name="{@rid}"/>
 		</xsl:if>
 		<a href="#{@rid}">
 			<xsl:apply-templates select="*|text()"/>
@@ -1322,7 +1322,7 @@
 	</xsl:template>
 	<xsl:template match="back/fn-group/fn/@fn-type"> </xsl:template>
 	<xsl:template match="back/fn-group/fn/@id">
-		<a name="back_{../@id}"/>
+		<a name="{../@id}"/>
 	</xsl:template>
 	<xsl:template match="back/fn-group/fn/label">
 		<xsl:choose>


### PR DESCRIPTION
El commit 410663f resuelve el issue #546, pero crea un nuevo problema con las notas al pie normales, ya que en están enlazadas de la siguiente forma `<a name="back_{../@id}"/>` 