### PR TITLE
[tk661] Alterar o sjr_format.pft para considerar o campo v435

### DIFF
--- a/proc/scielo_sjr/formats/sjr_format.pft
+++ b/proc/scielo_sjr/formats/sjr_format.pft
@@ -1,2 +1,6 @@
-'./sjr_proc.sh ',v400,' ',v400#
-'./sjr_proc.sh ',v400,' ',v935#
+,if p(v435) then
+  ,('./sjr_proc.sh ',v400[1],' ',v435^*,#),
+,else
+  ,'./sjr_proc.sh ',v400,' ',v400#,
+  ,if v400<>v935 then './sjr_proc.sh ',v400,' ',v935# fi,
+,fi


### PR DESCRIPTION
pois contem todos os tipos de ISSN adotados pelo periódico.

Fixes #661