### PR TITLE
Corrige o conteúdo de metatag *citation_title* para que seja o título no idioma acessado

### DIFF
--- a/cgi-bin/ScieloXML/sci_arttext.xis
+++ b/cgi-bin/ScieloXML/sci_arttext.xis
@@ -170,8 +170,7 @@
 		</pft>
 	</call>
 
-   <call name="CreateArticleTitle1XML"><pft>'^r'v4001^a'^l'v4001^l'^i'v4001^i'^h1'</pft></call>
-
+   <call name="CreateArticleTitle1XML"><pft>'^r'v4001^a'^l'v4001^l'^t'v4001^t'^i'v4001^i'^h1'</pft></call>
 
    <call name="CreateAuthorsGroupXML"><pft>v880</pft></call>
    <call name="CreateLattesGroupXML"><pft>v880</pft></call>	   

--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -2466,6 +2466,7 @@ fi
 <!-- Generate XML for Title of Article
      ^r - MFN 
 	 ^l - Interface Language 
+	 ^t - Text Language 
 	 ^i - International Language 
 	 ^f - Flag: 0 - preserve Html tags in title (absent - default: preserve)
 	            1 - remove Html tags from title
@@ -2499,6 +2500,8 @@ fi
   </proc>
 
   <call name="CreateArticleTitleXML"><pft>(v9999/)</pft></call>
+    <call name="citation_title"><pft>v4001^r,'^l',v4001^t</pft></call>
+
 </function>
 
 <function name="CreateIssueInfoXML" action="replace" tag="4001">
@@ -3564,6 +3567,26 @@ fi
 	
 </function>
 
+<function name="citation_title" action="replace" tag="4000">
+    <do task="mfnrange">
+        <parm name="db">ARTIGO</parm>
+        <parm name="from"><pft>v4000^*</pft></parm>
+        <parm name="count">1</parm>
+
+        <loop>
+			<field action="import"  tag="list">4000</field>
+            <display><pft>@PROC_SPLIT_MST.PFT,</pft></display>
+            <display><pft>
+            if v706='h' then 
+            	(if v4000^l[1]=v12^l then ,
+            		'<citation_title lang="',v12^l,'">',v12^*,| |v12^s,'</citation_title>',
+            	fi)
+            fi
+            </pft></display>
+        </loop>
+    </do>
+</function>
+
 	<function name="CreateArticleTitleForReference" action="replace" tag="4000">
 		<!--
 		Prints article title if present. Otherwise section name.
@@ -3601,12 +3624,14 @@ fi
 					      '  <NOHTML-TITLE><![CDATA[',
 					          ,v12^*[1],| |v12^s[1],
 						    ,']]></NOHTML-TITLE>'/,
+
+
                           fi
                           )		
                     fi
 				   </pft>
 				</display>	
-
+				<call name="citation_title"><pft>if v706='f' then f(mfn-1,1,0),'^l',v3100 fi</pft></call>
 					
 				<display>
 					<pft>

--- a/htdocs/xsl/plus/data.xsl
+++ b/htdocs/xsl/plus/data.xsl
@@ -67,11 +67,15 @@
             <xsl:when test="$doc//front//trans-title-group[@xml:lang=$PAGE_LANG]">
                 <xsl:apply-templates
                     select="$doc//front//trans-title-group[@xml:lang=$PAGE_LANG]/trans-title| $doc//front//trans-title-group[@xml:lang=$PAGE_LANG]/trans-subtitle" mode="DATA-DISPLAY"/>
-                
             </xsl:when>
-            <xsl:when test="$doc//front-stub//article-title[@xml:lang=$PAGE_LANG]">
+            <xsl:when test="$doc//sub-article[@xml:lang=$PAGE_LANG]//front-stub">
                 <xsl:apply-templates
-                    select="$doc//front-stub//article-title[@xml:lang=$PAGE_LANG] | $doc//front-stub//subtitle[@xml:lang=$PAGE_LANG]"
+                    select="$doc//sub-article[@xml:lang=$PAGE_LANG]//front-stub//article-title | $doc//sub-article[@xml:lang=$PAGE_LANG]//front-stub//subtitle"
+                    mode="DATA-DISPLAY"/>
+            </xsl:when>
+            <xsl:when test="$doc//sub-article[@xml:lang=$PAGE_LANG]//front">
+                <xsl:apply-templates
+                    select="$doc//sub-article[@xml:lang=$PAGE_LANG]//front//article-title | $doc//sub-article[@xml:lang=$PAGE_LANG]//front//subtitle"
                     mode="DATA-DISPLAY"/>
             </xsl:when>
             <xsl:otherwise>
@@ -122,6 +126,7 @@
         <meta name="citation_journal_title_abbrev" content="{.//journal-meta//abbrev-journal-title}"/>
         <meta name="citation_publisher" content="{.//journal-meta//publisher-name}"/>
         <meta name="citation_title" content="{$ARTICLE_TITLE}"/>
+        <meta name="citation_language" content="{$PAGE_LANG}"/>
 
         <meta name="citation_date"
             content="{.//article-meta//pub-date[1]//month}/{.//article-meta//pub-date[1]//year}"/>
@@ -178,22 +183,7 @@
         <xsl:value-of select=".//article-categories"/>
     </xsl:template>
     <xsl:template match="*" mode="DATA-DISPLAY-article-title">
-        <xsl:choose>
-            <xsl:when test="$doc//front//trans-title-group[@xml:lang=$PAGE_LANG]">
-                <xsl:apply-templates
-                    select="$doc//front//trans-title-group[@xml:lang=$PAGE_LANG]/trans-title| $doc//front//trans-title-group[@xml:lang=$PAGE_LANG]/trans-subtitle"  mode="DATA-DISPLAY"/>
-                
-            </xsl:when>
-            <xsl:when test="$doc//front-stub//article-title[@xml:lang=$PAGE_LANG]">
-                <xsl:apply-templates
-                    select="$doc//front-stub//article-title[@xml:lang=$PAGE_LANG] | $doc//front-stub//subtitle[@xml:lang=$PAGE_LANG]"  mode="DATA-DISPLAY"
-                />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates
-                    select="$doc//front//article-title | $doc//front//subtitle" mode="DATA-DISPLAY"/>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:value-of select="$ARTICLE_TITLE"/>
     </xsl:template>
     
 

--- a/htdocs/xsl/sci_abstract.xsl
+++ b/htdocs/xsl/sci_abstract.xsl
@@ -16,7 +16,7 @@
 			<html xmlns="http://www.w3.org/1999/xhtml" >
 			<head>
 				<title>
-					<xsl:value-of select="ARTICLE/NOHTML-TITLE" />
+					<xsl:value-of select="ARTICLE/citation_title" />
 				</title>
 				<meta http-equiv="Pragma" content="no-cache"/>
 				<meta http-equiv="Expires" content="Mon, 06 Jan 1990 00:00:01 GMT"/>
@@ -24,7 +24,8 @@
                 <!--Meta Google Scholar-->
                 <meta name="citation_journal_title" content="{TITLEGROUP/TITLE}"/>
                 <meta name="citation_publisher" content="{normalize-space(substring-after(COPYRIGHT,'-'))}"/>
-                <meta name="citation_title" content="{ARTICLE/NOHTML-TITLE}"/>                                
+                <meta name="citation_title" content="{ARTICLE/citation_title}"/>
+                <meta name="citation_language" content="{ARTICLE/citation_title/@lang}"/>                                
                 <meta name="citation_date" content="{concat(ARTICLE/ISSUEINFO/@MONTH,'/',ARTICLE/ISSUEINFO/@YEAR)}"/>
                 <meta name="citation_volume" content="{ARTICLE/ISSUEINFO/@VOL}"/>
                 <meta name="citation_issue" content="{ARTICLE/ISSUEINFO/@NUM}"/>

--- a/htdocs/xsl/sci_arttext.xsl
+++ b/htdocs/xsl/sci_arttext.xsl
@@ -178,7 +178,9 @@
 		<meta name="citation_journal_title" content="{TITLEGROUP/TITLE}"/>
 		<meta name="citation_journal_title_abbrev" content="{TITLEGROUP/SHORTTITLE}"/>
 		<meta name="citation_publisher" content="{normalize-space(COPYRIGHT)}"/>
-		<meta name="citation_title" content="{ISSUE/ARTICLE/TITLE}"/>
+		<meta name="citation_title" content="{ISSUE/ARTICLE/citation_title}"/>
+		<meta name="citation_language"
+			content="{ISSUE/ARTICLE/citation_title/@lang}"/>
 		<meta name="citation_date"
 			content="{concat(substring(ISSUE/@PUBDATE,5,2),'/',substring(ISSUE/@PUBDATE,1,4))}"/>
 		<meta name="citation_volume" content="{ISSUE/@VOL}"/>
@@ -225,7 +227,7 @@
 		<html xmlns="http://www.w3.org/1999/xhtml">
 			<head>
 				<title>
-					<xsl:value-of select="ISSUE/ARTICLE/TITLE" />
+					<xsl:value-of select="ISSUE/ARTICLE/citation_title" />
 				</title>
 				<xsl:apply-templates select="." mode="meta_names"/>
 
@@ -356,7 +358,7 @@
 		<html xmlns="http://www.w3.org/1999/xhtml">
 			<head>
 				<title>
-					<xsl:value-of select="ISSUE/ARTICLE/TITLE" />
+					<xsl:value-of select="ISSUE/ARTICLE/citation_title" />
 				</title>
 				<xsl:apply-templates select="." mode="meta_names"/>
 				<xsl:apply-templates select="." mode="version-css"/>
@@ -397,7 +399,7 @@
 	
 	<xsl:template match="SERIAL" mode="version-head-title">
 		<xsl:value-of select="TITLEGROUP/TITLE" disable-output-escaping="yes"/> - <xsl:value-of
-			select="normalize-space(ISSUE/ARTICLE/TITLE)" disable-output-escaping="yes"/>
+			select="normalize-space(ISSUE/ARTICLE/citation_title)" disable-output-escaping="yes"/>
 	</xsl:template>
 
 	<xsl:template match="SERIAL" mode="version-css">


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o conteúdo de metatag *citation_title* para que seja o título no idioma acessado na página do artigo, do resumo, e na página beta.
Também foi incluído *citation_language*
Para corrigir a página beta, foi corrigida a XSL que não estava selecionando o elemento correto para obter o título no idioma correspondente.
Para corrigir as páginas de resumo e do texto, foram ajustados tanto `.xis` como `.xsl`.

#### Onde a revisão poderia começar?
Página Beta
- htdocs/xsl/plus/data.xsl

Página de Resumo e Texto
- cgi-bin/ScieloXML/sci_common.xis:3570
- htdocs/xsl/sci_abstract.xsl
- htdocs/xsl/sci_arttext.xsl

#### Como este poderia ser testado manualmente?
Acessando as páginas:
- http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&pid=S0104-11692019000100300&lng=en&nrm=iso&tlng=es
- http://homolog.xml.scielo.br/scielo.php?script=sci_abstract&pid=S0104-11692019000100300&lng=en&nrm=iso&tlng=es
- http://homolog.xml.scielo.br/scielo.php?script=sci_arttext_plus&pid=S0104-11692019000100300&lng=en&nrm=iso&tlng=es

E visualizar no código fonte:

```<meta xmlns="" name="citation_title" content="Instrumento de medición: conocimientos, actitudes y prácticas en personas con tuberculosis pulmonar">```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#682
 
### Referências
N/A

