### PR TITLE
Converte entidades HTML na interface OAI

### DIFF
--- a/htdocs/oai/scielo-oai.php
+++ b/htdocs/oai/scielo-oai.php
@@ -132,6 +132,39 @@ $identifier = cleanParameter($identifier);
     
 	/**************************************** generateOAI_packet ****************************************/
 
+    /**
+     * Converts HTML entities codes to their HTML representation
+     * 
+     * This function search in the $string for HTML entity codes
+     * then tries to convert into their HTML representation 
+     * if they aren't in blacklist conversion ($cannot_convert).
+     * 
+     * @param string $string Represents the OAI results from XLST.
+     * 
+     * @return string String with html entities codes converted.
+     */
+    function convert_html_entities($string) {
+        $quantity = substr_count($string, "&");
+        $start_search_pos = 0;
+        $cannot_convert = array("&amp;", "&gt;", "&lt;");
+
+        while($quantity-- > 0) {
+            
+            $entity_start_pos = strpos($string, "&", $start_search_pos);
+            $entity_end_pos = strpos($string, ";", $entity_start_pos) + 1;
+            $entity = substr($string, $entity_start_pos, $entity_end_pos - $entity_start_pos);
+            $html_entity = html_entity_decode($entity, ENT_QUOTES, "UTF-8");
+
+            if (!in_array($entity, $cannot_convert) && $entity != $html_entity) {
+                $string = str_replace($entity, $html_entity, $string);
+            }
+
+            $start_search_pos = $entity_end_pos;
+        }
+
+        return $string;        
+    }
+
     function generateOAI_packet ( $request_uri, $verb, $payload )
     {
         global $identifier, $metadataPrefix, $from, $until, $set, $resumptionToken;
@@ -257,7 +290,7 @@ $identifier = cleanParameter($identifier);
         }
         
 		
-	    return $result;
+	    return convert_html_entities($result);
     }
 
 	/**************************************** verbo GetRecord **************************************/


### PR DESCRIPTION
#### O que esse PR faz?
Este PR converte as entidades html que estejam em formato de código/nome para as suas respectivas representações de caracter/símbolo em HTML. Mais explicações sobre a abordagem e algoritmo podem ser vistas no gist https://gist.github.com/joffilyfe/bc6daae8e7c5c40e496d1c2331307b41

#### Onde a revisão poderia começar?
- `htdocs/oai/scielo-oai.php` L: `146`

#### Como este poderia ser testado manualmente?

Deve-se:
- É necessário iniciar uma instância do Web a partir da branch (`tk-685`);
- Acessar o endereço: http://localhost:8080/oai/scielo-oai.php?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:scielo:S1020-49892007001100001
- Verificar a transformação das entidades HTML;
- Verificar que entidades como `&amp;` não foram transformadas.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

N/A

#### Quais são tickets relevantes?
#685 

### Referências
N/A


