### PR TITLE
Corrige a geração do "fecha" do CDATA para o OAI Agris

### DIFF
--- a/htdocs/oai/oai_agris_common.xsl
+++ b/htdocs/oai/oai_agris_common.xsl
@@ -63,7 +63,7 @@
 
 <xsl:template match="article-meta" mode="identifier">
         <!--dc:identifier scheme="dcterms:URI"><xsl:text disable-output-escaping="yes">&lt;![CDATA[http://www.scielo.br/scielo.php?script=sci_arttext&amp;pid=</xsl:text><xsl:value-of select="article-id"/><xsl:text disable-output-escaping="yes">]]&gt;</xsl:text></dc:identifier-->
-<dc:identifier scheme="dcterms:URI">&lt;![CDATA[<xsl:value-of select=".//self-uri[1]/@xlink:href"/>]]&gt;</dc:identifier>
+<dc:identifier scheme="dcterms:URI"><xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text><xsl:value-of select=".//self-uri[1]/@xlink:href"/><xsl:text disable-output-escaping="yes">]]&gt;</xsl:text></dc:identifier>
 	<dc:identifier scheme="ags:DOI"><xsl:value-of select=".//article-id[@pub-id-type='doi']"/></dc:identifier>
 </xsl:template>
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a geração do "fecha" do CDATA para o OAI Agris

#### Onde a revisão poderia começar?
htdocs/oai/oai_agris_common.xsl

#### Como este poderia ser testado manualmente?
Transformando o XML em anexo com o htdocs/oai/oai_agris_common.xsl (ou o htdos/oai/ListRecords_agris.xsl)

#### Algum cenário de contexto que queira dar?
ler comentário no ticket #688, https://github.com/scieloorg/Web/issues/688#issuecomment-517238275

### Screenshots
n/a

#### Quais são tickets relevantes?
#688

### Referências
n/a

