### PR TITLE
Apresenta DOI da tradução no lugar do DOI da versão original quando  aplicável

### DIFF
--- a/cgi-bin/ScieloXML/sci_arttext.xis
+++ b/cgi-bin/ScieloXML/sci_arttext.xis
@@ -150,7 +150,7 @@
     </pft>
    </display>
     
-   	<call name="displayDOIAttribute"><pft>v880</pft></call> 
+   	<call name="displayDOIAttribute"><pft>v880,|^l|v4001^t</pft></call>
 	<!-- fixed 20040622 -->
 	<field action="replace" tag="4040" split="occ"><pft>v4001^t</pft></field> 
 	<call name="showText"><pft>v264</pft></call>

--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -3333,12 +3333,27 @@ fi
 <function name="getDOI" action="replace" tag="880">
     <field action="import" tag="list">7011,237,9800</field>
 
+    <field action="replace" tag="9012"><pft>v880^l</pft></field>
+    <field action="replace" tag="880"><pft>if p(v880^l) then v880^* fi</pft></field>
+     
+    <field action="replace" tag="337" split="occ"><pft>
+    	ref(['ARTIGO']l(['ARTIGO'],'HR=',v880),@PROC_SPLIT_MST.PFT,(v337/))
+    </pft></field>
+    <field action="replace" tag="237"><pft>
+    	if p(v9012) and nocc(v337) > 1 then
+            (if v9012[1]=v337^l then v337^d, break fi)
+        fi
+    </pft></field>
+    <field action="replace" tag="237"><pft>
+    if a(v237) then
+		ref(['ARTIGO']l(['ARTIGO'],'HR=',v880),@PROC_SPLIT_MST.PFT, v237)
+	fi
+    </pft></field>
     <flow action="jump"><pft>if p(v237) then 'ok' fi</pft></flow>
     
     <!-- consulta a base doi/query -->
     <field action="replace" tag="237"><pft>if a(v237) then ref(['DOI']l(['DOI'],'pid=',v880),v237^*) fi</pft></field>
 	<field action="replace" tag="237"><pft>if a(v237) then ref(['DOIQUERY']l(['DOIQUERY'],'PID=',v880),v237) fi</pft></field>
-	
 	
     <flow action="jump"><pft>if p(v237) then 'ok' fi</pft></flow>
 	<field action="replace" tag="881"><pft>ref(['ARTIGO']l(['ARTIGO'],'HR=',v880),@PROC_SPLIT_MST.PFT,v881)</pft></field>

--- a/cgi-bin/ScieloXML/sci_isoref.xis
+++ b/cgi-bin/ScieloXML/sci_isoref.xis
@@ -212,7 +212,7 @@
                     ,fi
                 </pft>
             </display>
-			<call name="displayDOIAttribute"><pft>v880</pft></call>
+			<call name="displayDOIAttribute"><pft>v880,|^l|v3100</pft></call>
 			
 			<call name="formatDate"><pft>s(date)*0.8,'^l',v3000</pft></call>
 			<field action="replace"	tag="1000"><pft>v4444</pft></field>

--- a/cgi-bin/ScieloXML/sci_refrecord.xis
+++ b/cgi-bin/ScieloXML/sci_refrecord.xis
@@ -95,7 +95,7 @@
         </pft>
     </display>
             
-<call name="displayDOIAttribute"><pft>v880</pft></call>
+<call name="displayDOIAttribute"><pft>v880,|^l|v4001^o</pft></call>
 <call name="showText"><pft>v264</pft></call>
 
 			<call name="TestPDFPresence"><pft>if v8264<>'no' then v880 fi</pft></call>


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta DOI da tradução no lugar do DOI da versão original quando  aplicável

#### Onde a revisão poderia começar?
cgi-bin/ScieloXML/sci_common.xis

#### Como este poderia ser testado manualmente?
Acessando: 

- http://homolog.xml.scielo.br/scielo.php?script=sci_abstract&pid=S1983-68212019000200113&lng=en&nrm=iso&tlng=pt
- http://homolog.xml.scielo.br/scielo.php?script=sci_abstract&pid=S1983-68212019000200113&lng=en&nrm=iso&tlng=en
- http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&pid=S1983-68212019000200113&lng=en&nrm=iso&tlng=pt
- http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&pid=S1983-68212019000200113&lng=en&nrm=iso&tlng=en
- http://homolog.xml.scielo.br/scielo.php?script=sci_isoref&pid=S1983-68212019000200113&lng=en&tlng=pt
- http://homolog.xml.scielo.br/scielo.php?script=sci_isoref&pid=S1983-68212019000200113&lng=en&tlng=en

Note que há os DOIs:

-  http://dx.doi.org/10.1590/1983-6821201912277
-  http://dx.doi.org/10.1590/1983-6821201912278

#### Algum cenário de contexto que queira dar?
Outros exemplos:
Revista de administração pública v53n3 
Rev. Latinoam. Psicopat. Fund. 22(2)

### Screenshots

# Na página do artigo
<img width="786" alt="Captura de Tela 2019-08-12 às 10 29 08" src="https://user-images.githubusercontent.com/505143/62868448-1446d180-bcec-11e9-85d4-b81df34255ad.png">

# Em "Como citar"
<img width="526" alt="Captura de Tela 2019-08-12 às 10 28 39" src="https://user-images.githubusercontent.com/505143/62868452-16a92b80-bcec-11e9-94ea-67fdc89f5fe7.png">

# No resumo
<img width="523" alt="Captura de Tela 2019-08-12 às 10 28 14" src="https://user-images.githubusercontent.com/505143/62868458-1a3cb280-bcec-11e9-815b-b33019aac98e.png">


#### Quais são tickets relevantes?
#689 

### Referências
n/a

