### PR TITLE
Adiciona parser do history em front-stub

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -201,6 +201,9 @@
 				<xsl:when test=".//front//history">
 					<xsl:apply-templates select=".//front//history"/>
 				</xsl:when>
+				<xsl:when test=".//front-stub//history">
+					<xsl:apply-templates select=".//front-stub//history"/>
+				</xsl:when>
 				<xsl:when test=".//history">
 					<xsl:apply-templates select=".//front//history"/>
 				</xsl:when>


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a apresentação das datas de `recebido`, `aceite` e `revisado` de artigos que possuem traduções. Para não modificar eventuais comportamentos da aplicação foi escolhido adicionar um novo seletor para o elemento `history` do `front-stub`.

#### Onde a revisão poderia começar?
- `htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl` L: `204`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente deve-se:
- Iniciar uma nova instância do SciELO metodologia;
- Copiar bases `MST` de alguma coleção com artigos que possuem traduções;
- Acesse um artigo [[1]](http://192.168.169.125:8080/scielo.php?script=sci_arttext&pid=S0034-70942019000300227&lng=en&nrm=iso&tlng=en) no idioma original, verifique as datas do histórico;
- Acesse a tradução do artigo [[1]](http://192.168.169.125:8080/scielo.php?script=sci_arttext&pid=S0034-70942019000300227&lng=en&nrm=iso&tlng=pt), verifique a exibição das datas.


#### Algum cenário de contexto que queira dar?

Na linha `208` era possível alterar a XSL para algo como `<xsl:apply-templates select=".//history"/>` e a exibição das datas funcionaria como o esperado. Por **eu** não ter familiaridade com as regras de transformação do site atual, resolvi apenas adicionar um novo seletor para o `history` do `front-stub`.

### Screenshots
![Screen Shot 2019-10-14 at 14 13 13](https://user-images.githubusercontent.com/4604104/66770019-f2ed9780-ee8c-11e9-8096-a95f3890642a.png)
![Screen Shot 2019-10-14 at 14 13 48](https://user-images.githubusercontent.com/4604104/66770020-f2ed9780-ee8c-11e9-9794-229b90a96a05.png)

PS: A data da tradução foi alterada no XML local para dar ênfase no elemento que foi transformado pela XSLT.

#### Quais são tickets relevantes?
closes #691 

### Referências
N/A