### PR TITLE
Adiciona tradução para label de Publicado

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -1301,6 +1301,7 @@
 	<xsl:template match="history/date/@date-type" mode="scift-as-label-en">
 		<xsl:choose>
 			<xsl:when test=". = 'rev-recd'">Revised</xsl:when>
+			<xsl:when test=". = 'pub'">Published</xsl:when>
 			<xsl:otherwise>
 				<xsl:value-of select="translate(substring(.,1,1), 'ar', 'AR')"/>
 				<xsl:value-of select="substring(.,2)"/>
@@ -1312,6 +1313,7 @@
 			<xsl:when test=". = 'rev-recd'">Revisado</xsl:when>
 			<xsl:when test=". = 'accepted'">Aceito</xsl:when>
 			<xsl:when test=". = 'received'">Recebido</xsl:when>
+			<xsl:when test=". = 'pub'">Publicado</xsl:when>
 		</xsl:choose>
 	</xsl:template>
 	<xsl:template match="history/date/@date-type" mode="scift-as-label-es">
@@ -1319,6 +1321,7 @@
 			<xsl:when test=". = 'rev-recd'">Revisado</xsl:when>
 			<xsl:when test=". = 'accepted'">Aprobado</xsl:when>
 			<xsl:when test=". = 'received'">Recibido</xsl:when>
+			<xsl:when test=". = 'pub'">Publicado</xsl:when>
 		</xsl:choose>
 	</xsl:template>
 	<xsl:template match="history/date">


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige o problema apontado no comentário (https://github.com/scieloorg/Web/issues/691#issuecomment-543867953) e adiciona o rótulo de `publicado` para as datas do tipo `pub`.

#### Onde a revisão poderia começar?

- `htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl` L: `1315` e `1323`

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente deve-se:

- Iniciar uma instância do Web com uma base contendo artigos com o campo `pub` no `history`;
- Verificar que a tradução é exibida para artigos com o `history` em `front-stub`.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #691

### Referências
N/A


