### PR TITLE
Apresenta todos os resumos e palavras-chaves no texto

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -316,8 +316,8 @@
 	<xsl:template match="abstract | trans-abstract">
 		<xsl:variable name="lang"><xsl:choose>
 			<xsl:when test="@xml:lang"><xsl:value-of select="@xml:lang"/></xsl:when>
-			<xsl:when test="$trans"><xsl:value-of select="$trans/@xml:lang"/></xsl:when>
-			<xsl:otherwise><xsl:value-of select="$original/@xml:lang"/></xsl:otherwise>
+			<xsl:when test="../../../@xml:lang"><xsl:value-of select="../../../@xml:lang"/></xsl:when>
+			<xsl:when test="../../@xml:lang"><xsl:value-of select="../../@xml:lang"/></xsl:when>
 		</xsl:choose></xsl:variable>
 		<div>
 			<!--Apresenta o título da seção conforme a lingua existente-->
@@ -341,12 +341,8 @@
 			
 			<xsl:apply-templates select="*[name()!='title'] | text()"/>
 			<xsl:apply-templates
-				select="..//kwd-group[normalize-space(@xml:lang)=normalize-space($lang)]"
+				select="$original//kwd-group[normalize-space(@xml:lang)=normalize-space($lang)]"
 				mode="keywords"/>
-			<xsl:if test="not(..//kwd-group[normalize-space(@xml:lang)=normalize-space($lang)])">
-				<xsl:apply-templates
-						select="..//kwd-group[not(@xml:lang)]"
-						mode="keywords"/>
 			</xsl:if>
 		</div>
 	</xsl:template>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -293,11 +293,13 @@
 	</xsl:template>
 
 	<xsl:template match="front" mode="all-the-abstracts-and-keywords">
+		<hr/>
 		<xsl:apply-templates select="article-meta" mode="abstract-and-keywords"/>
 		<xsl:apply-templates select="$original//sub-article[@article-type='translation']/front-stub" mode="abstract-and-keywords"/>
 	</xsl:template>
 
 	<xsl:template match="front-stub" mode="all-the-abstracts-and-keywords">
+		<hr/>
 		<xsl:apply-templates select="." mode="abstract-and-keywords"/>
 		<xsl:apply-templates select="$original//article-meta" mode="abstract-and-keywords"/>
 		<xsl:apply-templates select="$original//sub-article[@article-type='translation' and @xml:lang!=$lang]/front-stub" mode="abstract-and-keywords"/>
@@ -319,9 +321,7 @@
 		</xsl:choose></xsl:variable>
 		<div>
 			<!--Apresenta o título da seção conforme a lingua existente-->
-			<xsl:attribute name="class">
-				<xsl:value-of select="name()"/>
-			</xsl:attribute>
+			<xsl:attribute name="class">trans-abstract</xsl:attribute>
 			<p class="sec">
 				<xsl:choose>
 					<xsl:when test="title">

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -292,6 +292,14 @@
 		</xsl:if>
 	</xsl:template>
 
+	<xsl:template match="article-meta | front-stub" mode="abstract-and-keywords">
+		<xsl:apply-templates select="abstract"/>
+		<xsl:apply-templates select="trans-abstract"/>
+		<xsl:if test="not(abstract) and not(trans-abstract)">
+			<xsl:apply-templates select="kwd-group" mode="keywords"></xsl:apply-templates>
+		</xsl:if>
+	</xsl:template>
+
 	<xsl:template match="abstract | trans-abstract">
 		<xsl:variable name="lang"><xsl:choose>
 			<xsl:when test="@xml:lang"><xsl:value-of select="@xml:lang"/></xsl:when>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -313,8 +313,8 @@
 	<xsl:template match="abstract | trans-abstract">
 		<xsl:variable name="lang"><xsl:choose>
 			<xsl:when test="@xml:lang"><xsl:value-of select="@xml:lang"/></xsl:when>
-			<xsl:when test="../../../@xml:lang"><xsl:value-of select="../../../@xml:lang"/></xsl:when>
-			<xsl:when test="../../@xml:lang"><xsl:value-of select="../../@xml:lang"/></xsl:when>
+			<xsl:when test="../../front-stub"><xsl:value-of select="../../@xml:lang"/></xsl:when>
+			<xsl:when test="../../article-meta"><xsl:value-of select="../../../@xml:lang"/></xsl:when>
 		</xsl:choose></xsl:variable>
 		<div>
 			<!--Apresenta o título da seção conforme a lingua existente-->

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -295,6 +295,7 @@
 	</xsl:template>
 
 	<xsl:template match="front-stub" mode="all-the-abstracts-and-keywords">
+		<xsl:variable name="lang" select="../@xml:lang"/>
 		<hr/>
 		<xsl:apply-templates select="." mode="abstract-and-keywords"/>
 		<xsl:apply-templates select="$original//article-meta" mode="abstract-and-keywords"/>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -258,10 +258,8 @@
 			<xsl:apply-templates select="../..//front//aff"/>
 		</xsl:if>
 		<xsl:apply-templates select="../..//front//supplementary-material|../..//front//product"/>
-		<xsl:apply-templates select=".//abstract"/>
-		<xsl:if test="not(.//abstract)">
-			<xsl:apply-templates select=".//kwd-group" mode="keywords"></xsl:apply-templates>
-		</xsl:if>
+		
+		<xsl:apply-templates select="." mode="all-the-abstracts-and-keywords"/>
 		
 	</xsl:template>
 
@@ -286,10 +284,8 @@
 		
 		<p><xsl:apply-templates select=".//supplementary-material"/></p>
 		<p><xsl:apply-templates select=".//product"/></p>
-		<xsl:apply-templates select=".//abstract | .//trans-abstract"/>
-		<xsl:if test="not(.//abstract) and not(.//trans-abstract)">
-			<xsl:apply-templates select=".//kwd-group" mode="keywords"></xsl:apply-templates>
-		</xsl:if>
+		<xsl:apply-templates select="." mode="all-the-abstracts-and-keywords"/>
+
 	</xsl:template>
 
 	<xsl:template match="front" mode="all-the-abstracts-and-keywords">

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -292,6 +292,17 @@
 		</xsl:if>
 	</xsl:template>
 
+	<xsl:template match="front" mode="all-the-abstracts-and-keywords">
+		<xsl:apply-templates select="article-meta" mode="abstract-and-keywords"/>
+		<xsl:apply-templates select="$original//sub-article[@article-type='translation']/front-stub" mode="abstract-and-keywords"/>
+	</xsl:template>
+
+	<xsl:template match="front-stub" mode="all-the-abstracts-and-keywords">
+		<xsl:apply-templates select="." mode="abstract-and-keywords"/>
+		<xsl:apply-templates select="$original//article-meta" mode="abstract-and-keywords"/>
+		<xsl:apply-templates select="$original//sub-article[@article-type='translation' and @xml:lang!=$lang]/front-stub" mode="abstract-and-keywords"/>
+	</xsl:template>
+
 	<xsl:template match="article-meta | front-stub" mode="abstract-and-keywords">
 		<xsl:apply-templates select="abstract"/>
 		<xsl:apply-templates select="trans-abstract"/>

--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -339,7 +339,6 @@
 			<xsl:apply-templates
 				select="$original//kwd-group[normalize-space(@xml:lang)=normalize-space($lang)]"
 				mode="keywords"/>
-			</xsl:if>
 		</div>
 	</xsl:template>
 


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta todos os resumos e palavras-chaves no texto, independentemente do idioma do texto, ou de onde está declarado na estrutura do XML.

#### Onde a revisão poderia começar?
Revisar por commits.

#### Como este poderia ser testado manualmente?
ter uma instância com a correção. 

#### Algum cenário de contexto que queira dar?
A lógica anterior, somente apresentava o resumo no contexto do article-meta ou sub-article.
Então, o texto completo era proveniente do article/body, os resumos que estavam em article-meta eram apresentados, excluindo os resumos encontrados nos sub-articles. Caso o texto completo era proveniente do sub-article/body, eram apresentados os resumos do contexto do sub-article.

Em consequência, desta mudança para quaisquer textos, serão apresentados todos os resumos.

### Screenshots
Como estava:

No texto em Português
<img width="830" alt="Captura de Tela 2019-11-12 às 17 48 16" src="https://user-images.githubusercontent.com/505143/68709683-f4d27580-0574-11ea-9420-8f59d1f17a9c.png">

No texto em Inglês
<img width="858" alt="Captura de Tela 2019-11-12 às 17 48 05" src="https://user-images.githubusercontent.com/505143/68709692-f7cd6600-0574-11ea-860b-7292df703b6c.png">

Como ficou:
No texto em Português:
<img width="907" alt="Captura de Tela 2019-11-12 às 17 48 55" src="https://user-images.githubusercontent.com/505143/68709658-ee43fe00-0574-11ea-91be-101a11544ac6.png">

No texto em Inglês:
<img width="842" alt="Captura de Tela 2019-11-12 às 17 49 12" src="https://user-images.githubusercontent.com/505143/68709653-ec7a3a80-0574-11ea-9dad-9ae919964c39.png">


#### Quais são tickets relevantes?
#698 

### Referências
n/a
