### PR TITLE
Devolve o resultado do oai que está quebrando porque há um & que não está no formato de entidade

### DIFF
--- a/htdocs/oai/oai_common.xsl
+++ b/htdocs/oai/oai_common.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	
 	<xsl:variable name="CONTROLINFO" select="//CONTROLINFO[1]" />
 	<xsl:variable name="doc_type_conversor" select="document('doc_types_openaire.xml')/doc_types" />
@@ -141,10 +141,9 @@
 	
 	<xsl:template match="CONTROLINFO" mode="identifier">
 		<xsl:param name="PID" select="PAGE_PID" />
-		<xsl:call-template name="escaped_element">
-			<xsl:with-param name="name">dc:identifier</xsl:with-param>
-			<xsl:with-param name="value">http://<xsl:value-of select="concat(SCIELO_INFO/SERVER, SCIELO_INFO/PATH_DATA)"/>scielo.php?script=sci_arttext&amp;amp;pid=<xsl:value-of select="$PID"/></xsl:with-param>			
-		</xsl:call-template>
+
+		<dc:identifier>http://<xsl:value-of select="concat(SCIELO_INFO/SERVER, SCIELO_INFO/PATH_DATA)"/>scielo.php?script=sci_arttext<xsl:text  disable-output-escaping="no">&amp;</xsl:text>pid=<xsl:value-of select="$PID"/></dc:identifier>
+
 	</xsl:template>
 	
 	<xsl:template match="PUBLISHER">

--- a/htdocs/oai/scielo-oai.php
+++ b/htdocs/oai/scielo-oai.php
@@ -153,10 +153,17 @@ $identifier = cleanParameter($identifier);
             $entity_start_pos = strpos($string, "&", $start_search_pos);
             $entity_end_pos = strpos($string, ";", $entity_start_pos) + 1;
             $entity = substr($string, $entity_start_pos, $entity_end_pos - $entity_start_pos);
-            $html_entity = html_entity_decode($entity, ENT_QUOTES, "UTF-8");
 
-            if (!in_array($entity, $cannot_convert) && $entity != $html_entity) {
-                $string = str_replace($entity, $html_entity, $string);
+            if (!strrpos($entity, " ")) {
+                // texto pode ser uma entidade, pois nao contem espaco
+                if (!in_array($entity, $cannot_convert)) {
+                    // entidade que nao esta' na lista $cannot_convert
+                    $html_entity = html_entity_decode($entity, ENT_QUOTES, "UTF-8");
+                    if ($entity != $html_entity) {
+                        // conseguiu converter
+                        $string = str_replace($entity, $html_entity, $string);
+                    }
+                }
             }
 
             $start_search_pos = $entity_end_pos;


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o resultado do oai que está quebrando porque há um & que não está no formato de entidade

#### Onde a revisão poderia começar?
`htdocs/oai/scielo-oai.php. L:157`

#### Como este poderia ser testado manualmente?
Incorreto
http://www.scielo.br/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=2523-3106

Correto
http://homolog.xml.scielo.br/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=2523-3106

#### Algum cenário de contexto que queira dar?
A alteração na XSL não afetou o resultado do XML. No entanto, seria a forma apropriada para criar um novo elemento. Eu tinha pensado que o problema estava neste template.

O problema foi que o scielo-oai.php tinha convertido um `&amp;` para `&` quebrando o resultado.

`& anti-nucleosome antibodies.  Results: Anti-C1q antibody showed a statistically significant association with the presence of vasculitis and nephritis while anti-nucleosome antibody didn't show a significant association with the presence of any clinical features. Double positivity of anti-nucleosome and anti-C1q antibodies showed a statistically significant association with the presence of vasculitis and photosensitivity, high ECLAM score, elevated ESR, low serum albumin and low C3 levels.  Conclusion: Serum anti-C1q antibody has a significant association with LN while double positive antibodies have a significant association with vasculitis and low C3 levels in Egyptian patients with SLE.]]></dc:description><dc:rights>info:eu-repo/semantics/openAccess</dc:rights><dc:publisher><![CDATA[Sociedade Brasileira de Reumatologia]]></dc:publisher><dc:source><![CDATA[Advances in Rheumatology  v.59 2019]]></dc:source><dc:date>2019-01-01</dc:date><dc:type>info:eu-repo/semantics/article</dc:type><dc:format>text/html</dc:format><dc:identifier>http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&amp;` 
tinha sido identificado como uma entidade e foi convertido para 
`& anti-nucleosome antibodies.  Results: Anti-C1q antibody showed a statistically significant association with the presence of vasculitis and nephritis while anti-nucleosome antibody didn't show a significant association with the presence of any clinical features. Double positivity of anti-nucleosome and anti-C1q antibodies showed a statistically significant association with the presence of vasculitis and photosensitivity, high ECLAM score, elevated ESR, low serum albumin and low C3 levels.  Conclusion: Serum anti-C1q antibody has a significant association with LN while double positive antibodies have a significant association with vasculitis and low C3 levels in Egyptian patients with SLE.]]></dc:description><dc:rights>info:eu-repo/semantics/openAccess</dc:rights><dc:publisher><![CDATA[Sociedade Brasileira de Reumatologia]]></dc:publisher><dc:source><![CDATA[Advances in Rheumatology  v.59 2019]]></dc:source><dc:date>2019-01-01</dc:date><dc:type>info:eu-repo/semantics/article</dc:type><dc:format>text/html</dc:format><dc:identifier>http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&`

gerando no final um caracter `&` que é inváldo no XML.


### Screenshots
n/a

#### Quais são tickets relevantes?
#701 

### Referências
n/a
