### PR TITLE
Se há sub-article//ref-list, apresentá-la, ao invés apresentar articl…

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -1154,12 +1154,18 @@
 		<xsl:apply-templates select="ref"></xsl:apply-templates>
 	</xsl:template>
 	
-	<xsl:template match="sub-article[@article-type='translation']/back//ref-list[ref]" mode="ref-items">
-		<xsl:apply-templates select="$original/back/ref-list/ref"/>
+	<xsl:template match="sub-article[@article-type='translation']/back//ref-list" mode="ref-items">
+		<xsl:choose>
+			<xsl:when test="ref"><xsl:apply-templates select="ref"></xsl:apply-templates></xsl:when>
+			<xsl:otherwise><xsl:apply-templates select="$original/back/ref-list/ref"/></xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 	
-	<xsl:template match="sub-article[@article-type='translation']/response/back//ref-list[ref]" mode="ref-items">
-		<xsl:apply-templates select="$original/response/back/ref-list/ref"/>
+	<xsl:template match="sub-article[@article-type='translation']/response/back//ref-list" mode="ref-items">
+		<xsl:choose>
+			<xsl:when test="ref"><xsl:apply-templates select="ref"></xsl:apply-templates></xsl:when>
+			<xsl:otherwise><xsl:apply-templates select="$original/response/back/ref-list/ref"/></xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 	
 	<xsl:template match="ref">


### PR DESCRIPTION
…e/back/ref-list.

#### O que esse PR faz?
Remove a "duplicação" de referências na página do artigo. Há artigos com traduções que traduzem as referências. Isso não era esperado.  A solução é considerar se há ref-list dentro de sub-article, o que vale é a ref-list de sub-article. Caso contrário, se no sub-article (translation) não tem ref-list, apresentar a article/back/ref-list no lugar.

#### Onde a revisão poderia começar?
htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl

#### Como este poderia ser testado manualmente?
http://homolog.xml.scielo.br/scielo.php?script=sci_arttext&pid=S0102-01882019000300153&lng=en&nrm=iso&tlng=en

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#703 

### Referências
n/a