### PR TITLE
Corrige bug na decodificação de caracteres UTF-8

### DIFF
--- a/htdocs/oai/scielo-oai.php
+++ b/htdocs/oai/scielo-oai.php
@@ -159,7 +159,7 @@ $identifier = cleanParameter($identifier);
                 if (!in_array($entity, $cannot_convert)) {
                     // entidade que nao esta' na lista $cannot_convert
                     $html_entity = html_entity_decode($entity, ENT_QUOTES, "UTF-8");
-                    if ($entity != $html_entity) {
+                    if ($entity != $html_entity && (ctype_print($html_entity) || preg_match("//u", $html_entity))) {
                         // conseguiu converter
                         $string = str_replace($entity, $html_entity, $string);
                     }


### PR DESCRIPTION
O erro se manifestava na URL /oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=0102-8650&resumptionToken=HR__S0102-86502019000100202:0102-8650:::oai_dc,
do endpoint do protocolo OAI-PMH, ao decodificar a referência numéricas
`&#55349;` que não corresponde a um caractere unicode válido.

A solução foi adicionar uma checagem com expressão regular que casa apenas com
caracteres UTF-8 válidos, conforme descrito em:
https://www.php.net/manual/pt_BR/function.mb-detect-encoding.php#112391

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Acesse `/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc&set=0102-8650&resumptionToken=HR__S0102-86502019000100202:0102-8650:::oai_dc` antes e depois de aplicar o patch.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
https://www.php.net/manual/pt_BR/function.mb-detect-encoding.php#112391

