### PR TITLE
Exibe os DOIs de acordo com as diretrizes do Crossref

### DIFF
--- a/cgi-bin/ScieloXML/sci_isoref.xis
+++ b/cgi-bin/ScieloXML/sci_isoref.xis
@@ -274,7 +274,7 @@
                      fi,
                     ,|Epub |v9223|.|
                     ,if p(v237) then
-                        ,'<a href="https://dx.doi.org/',v237,'">https://dx.doi.org/',v237,'</a>',
+                        ,'<a href="https://doi.org/',v237,'">https://doi.org/',v237,'</a>',
                     ,else
                         ,if v3000='en' then
                         	,' Retrieved ',

--- a/cgi-bin/ScieloXML/sci_nlinks.xis
+++ b/cgi-bin/ScieloXML/sci_nlinks.xis
@@ -194,9 +194,9 @@ IsisScript que gera o XML Para a tela de links da referencia bibliografica
       <pft>if p(v9352) then
         if not v9352:'http' then
            if s(mpu,v9352,mpl):'DOI:' then
-               'http://dx.doi.org/',mid(v9352,instr(v9352,':')+1,size(v9352))
+               'https://doi.org/',mid(v9352,instr(v9352,':')+1,size(v9352))
            else
-               'http://dx.doi.org/',v9352
+               'https://doi.org/',v9352
            fi
         fi fi
       </pft>

--- a/cgi-bin/ScieloXML/sci_reflinks.xis
+++ b/cgi-bin/ScieloXML/sci_reflinks.xis
@@ -164,7 +164,7 @@ IsisScript que gera o XML Para a tela de links da referencia bibliografica
 
 	<!-- Se o doi vier via cgi ou existir no registro c ou r n�o h� necessidade de consultar a base doi -->
 	<call name="getDOILink"><pft>if a(v9352) then v3002 fi</pft></call>
-	<field action="replace" tag="9999"><pft>if p(v9352) then '<a href="http://dx.doi.org/',v9352,'">CrossRef</a>' fi</pft></field>
+	<field action="replace" tag="9999"><pft>if p(v9352) then '<a href="https://doi.org/',v9352,'">CrossRef</a>' fi</pft></field>
 	
 	
 

--- a/htdocs/xsl/plus/data.xsl
+++ b/htdocs/xsl/plus/data.xsl
@@ -347,7 +347,7 @@
         <xsl:value-of select="@pub-id-type"/>: <xsl:value-of select="."/>
     </xsl:template>
     <xsl:template match="pub-id[@pub-id-type='doi']| comment[contains(.,'doi:')]"
-        mode="DATA-DISPLAY"> http://dx.doi.org/<xsl:value-of select="."/>
+        mode="DATA-DISPLAY"> https://doi.org/<xsl:value-of select="."/>
     </xsl:template>
     <xsl:template match="suffix">
         <xsl:value-of select="concat(' ',.)"/>

--- a/htdocs/xsl/plus/layout.xsl
+++ b/htdocs/xsl/plus/layout.xsl
@@ -231,8 +231,8 @@
                         <xsl:apply-templates select="." mode="DATA-issue-label"/>
                     </div>
                     <div class="span4 doi-url hidden-tablet hidden-phone">
-                            http://dx.doi.org/<xsl:apply-templates
-                            select=".//article-meta//*[@pub-id-type='doi']"/>
+                        <xsl:variable name="doi-link">https://doi.org/<xsl:apply-templates select=".//article-meta//*[@pub-id-type='doi']"/></xsl:variable>
+                        <a href='{$doi-link}'><xsl:value-of select="$doi-link"/></a>
                     </div>
                 </div>
             </div>

--- a/htdocs/xsl/sci_common.xsl
+++ b/htdocs/xsl/sci_common.xsl
@@ -1095,8 +1095,9 @@
         <xsl:value-of select="."/>
     </xsl:template>
 
-    <xsl:template match="@DOI" mode="display"> http://dx.doi.org/<xsl:value-of
-            select="translate(.,' ','')"/>
+    <xsl:template match="@DOI" mode="display">
+        <xsl:variable name="doi-link">https://doi.org/<xsl:value-of select="translate(.,' ','')"/></xsl:variable>
+        <a href='{$doi-link}'><xsl:value-of select="$doi-link"/></a>
     </xsl:template>
 
     <!--


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request realiza alterações pontuais nos arquivos que de alguma maneira exibem os `DOIs` dos artigos. As páginas de texto completo, "como citar" e "nlinks" foram modificadas.

#### Onde a revisão poderia começar?
- `htdocs/xsl/sci_common.xsl` L: `1098`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente, deve-se:
- Crie uma instância do SciELO metodologia [[2]](###comandos);
- Atualize as bases de acordo com seu teste (ex: as bases mst, xml de scielo br e medline);
- Navegue entre artigos, verifique os links de `DOI`;
- Verifique os link em `"como citar"`;
- Verifique os links na página `arttext_plus`;

#### Algum cenário de contexto que queira dar?

Não foram aplicados estilos em cascata para alterar a exibição, as cores, tamanhos ou fontes dos links. Sendo assim os links não terão uma aparência especial.

### Screenshots
![Screen Shot 2020-02-11 at 15 27 29](https://user-images.githubusercontent.com/4604104/74268167-2549bd00-4ce6-11ea-97d8-2cad157cc4af.png)
![Screen Shot 2020-02-11 at 15 28 21](https://user-images.githubusercontent.com/4604104/74268173-2844ad80-4ce6-11ea-8009-d450f41f4731.png)


#### Quais são tickets relevantes?
N/A

### Referências
[[1] - Crossref DOI Guidelines_pt](https://docs.google.com/document/d/1K3Lj031Q6LqYxo33Byh0EzywskO-ywkKg526ENqYa54/edit#)

### Comandos
[2] - Criando uma nova instância de scielo metodologia

```bash
export SCIELO_FOLDER="$HOME/metodologia/dados-master"

docker run --name scielo-master -v "$SCIELO_FOLDER/scielo":/var/www/scielo \
    -v "$SCIELO_FOLDER/logs":/var/www/apache \
    --env INSTANCE_NAME=scielo_scl_master \
    --env USER_SUPERVISOR=root \
    --env PASS_SUPERVISOR=toor \
    --env SITE_NAME=localhost:8080 \
    --env USER_FTP=teste \
    --env PASSWD_FTP=teste \
    --env USER_PASS=scielo \
    --env GIT_BRANCH_NAME=master \
    -p 8080:8080 -p 2223:2222 -d scieloorg/metodologia:latest
```