### PR TITLE
Cria parte do utilitário para incluir DOI nos registros h e f de uma data bases

### DIFF
--- a/proc/scielo_doi/app/cisis.py
+++ b/proc/scielo_doi/app/cisis.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import os
-from datetime import datetime
 
 
 CISIS = "cisis/mx"
@@ -20,6 +19,8 @@ def update_command(db, mfn, count, proc):
 
 
 def execute(cmd):
+    # TODO usar subprocess
+    # TODO remover esta funcao deste modulo
     os.system(cmd)
 
 
@@ -43,15 +44,12 @@ def proc_update_doi(file_path, doi, doi_items):
         )
 
 
-def proc_update_datetime(file_path):
+def proc_update_datetime(file_path, update_date, update_time):
     """
     Retorna a "proc" que atualiza
     os campos v91 (data) e v92 (hora) da atualização
     """
-    now = datetime.now().isoformat()
-    d = now[:10].replace("-", "")
-    t = now[11:16].replace(":", "")
-    proc = "'d91d92a91~{}~a92~{}~'".format(d, t)
+    proc = "'d91d92a91~{}~a92~{}~'".format(update_date, update_time)
     return "if v706='o' and v702='{}' then {} fi".format(
             file_path,
             proc
@@ -59,14 +57,14 @@ def proc_update_datetime(file_path):
 
 
 def get_commands_to_update_ohf_records_of_a_doc(
-        db, file_path, h_mfn, doi, doi_items):
+        db, file_path, h_mfn, doi, doi_items, update_date, update_time):
     """
     Gera dois comandos para atualizar 1 documento os registros:
     - h e f: os campos v237 com DOI original e 337 todos os DOI com idioma
     - o: os campos v91 (data) e v92 (hora) da atualização
     """
     o_mfn = str(int(h_mfn) - 1)
-    o_proc = proc_update_datetime(file_path)
+    o_proc = proc_update_datetime(file_path, update_date, update_time)
     o_cmd = update_command(db, o_mfn, 1, o_proc)
     hf_proc = proc_update_doi(file_path, doi, doi_items)
     hf_cmd = update_command(db, h_mfn, 2, hf_proc)

--- a/proc/scielo_doi/app/cisis.py
+++ b/proc/scielo_doi/app/cisis.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+import os
+from datetime import datetime
+
+
+CISIS = "cisis/mx"
+
+
+def update_command(db, mfn, count, proc):
+    cmd = ("{CISIS} {db} from={mfn} count={count} "
+           "\"proc={proc}\""
+           " copy={db} now -all").format(
+            CISIS=CISIS,
+            db=db,
+            mfn=mfn,
+            count=count,
+            proc=proc
+        )
+    return cmd
+
+
+def execute(cmd):
+    os.system(cmd)
+
+
+def proc_update_doi(file_path, doi, doi_items):
+    """
+    Retorna a "proc" que atualiza
+    os campos v237 com DOI original e 337 todos os DOI com idioma
+    """
+    if not file_path:
+        raise ValueError("Invalid value for file_path")
+    if not doi:
+        raise ValueError("Invalid value for DOI")
+    proc_d = "'d337d237a237~{}~'".format(doi)
+    proc_a337 = [
+        ",'a337~^l{}^d{}~'".format(lang, _doi)
+        for lang, _doi in doi_items
+    ]
+    return "if 'hf':v706 and v702='{}' then {} fi".format(
+            file_path,
+            proc_d + ''.join(proc_a337)
+        )
+
+
+def proc_update_datetime(file_path):
+    """
+    Retorna a "proc" que atualiza
+    os campos v91 (data) e v92 (hora) da atualização
+    """
+    now = datetime.now().isoformat()
+    d = now[:10].replace("-", "")
+    t = now[11:16].replace(":", "")
+    proc = "'d91d92a91~{}~a92~{}~'".format(d, t)
+    return "if v706='o' and v702='{}' then {} fi".format(
+            file_path,
+            proc
+        )
+
+
+def get_commands_to_update_ohf_records_of_a_doc(
+        db, file_path, h_mfn, doi, doi_items):
+    """
+    Gera dois comandos para atualizar 1 documento os registros:
+    - h e f: os campos v237 com DOI original e 337 todos os DOI com idioma
+    - o: os campos v91 (data) e v92 (hora) da atualização
+    """
+    o_mfn = str(int(h_mfn) - 1)
+    o_proc = proc_update_datetime(file_path)
+    o_cmd = update_command(db, o_mfn, 1, o_proc)
+    hf_proc = proc_update_doi(file_path, doi, doi_items)
+    hf_cmd = update_command(db, h_mfn, 2, hf_proc)
+    return [o_cmd, hf_cmd]

--- a/proc/scielo_doi/setup.py
+++ b/proc/scielo_doi/setup.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import os
+import setuptools
+
+here = os.path.abspath(os.path.dirname(__file__))
+README = CHANGES = ""
+# with open(os.path.join(here, "README.md")) as f:
+#     README = f.read()
+# with open(os.path.join(here, "CHANGES.txt")) as f:
+#     CHANGES = f.read()
+
+requires = [
+
+]
+
+tests_require = [
+]
+
+setuptools.setup(
+    name="scielo_doi",
+    version="0.1",
+    author="SciELO",
+    author_email="scielo-dev@googlegroups.com",
+    description="",
+    long_description=README + "\n\n" + CHANGES,
+    long_description_content_type="text/markdown",
+    license="2-clause BSD",
+    packages=setuptools.find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]
+    ),
+    include_package_data=True,
+    extras_require={"testing": tests_require},
+    install_requires=requires,
+    # dependency_links=[
+    # ],
+    python_requires=">=3.6",
+    test_suite="tests",
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Environment :: Other Environment",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
+    ],
+
+    # entry_points="",
+)

--- a/proc/scielo_doi/setup.py
+++ b/proc/scielo_doi/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import os
 import setuptools
 
@@ -33,15 +32,11 @@ setuptools.setup(
     install_requires=requires,
     # dependency_links=[
     # ],
-    python_requires=">=3.6",
     test_suite="tests",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Other Environment",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3 :: Only",
     ],
 
     # entry_points="",

--- a/proc/scielo_doi/setup.py
+++ b/proc/scielo_doi/setup.py
@@ -1,19 +1,5 @@
-import os
 import setuptools
 
-here = os.path.abspath(os.path.dirname(__file__))
-README = CHANGES = ""
-# with open(os.path.join(here, "README.md")) as f:
-#     README = f.read()
-# with open(os.path.join(here, "CHANGES.txt")) as f:
-#     CHANGES = f.read()
-
-requires = [
-
-]
-
-tests_require = [
-]
 
 setuptools.setup(
     name="scielo_doi",
@@ -21,23 +7,10 @@ setuptools.setup(
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",
     description="",
-    long_description=README + "\n\n" + CHANGES,
-    long_description_content_type="text/markdown",
     license="2-clause BSD",
     packages=setuptools.find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]
     ),
     include_package_data=True,
-    extras_require={"testing": tests_require},
-    install_requires=requires,
-    # dependency_links=[
-    # ],
     test_suite="tests",
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Environment :: Other Environment",
-        "License :: OSI Approved :: BSD License",
-    ],
-
-    # entry_points="",
 )

--- a/proc/scielo_doi/tests/test_cisis.py
+++ b/proc/scielo_doi/tests/test_cisis.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+from unittest.mock import patch
+from datetime import datetime
+
+from app import cisis
+
+
+class TestCisis(TestCase):
+
+    def test_update_command(self):
+        db = "base"
+        mfn = 100
+        count = 5
+        proc = '@a.proc'
+        result = cisis.update_command(db, mfn, count, proc)
+        self.assertEqual(
+            result,
+            "cisis/mx base from=100 count=5 \"proc=@a.proc\" copy=base now -all"
+        )
+
+    def test_proc_update_doi(self):
+        file_path = "xml/abc/v1n1/a.xml"
+        doi = "DOI"
+        doi_items = [
+            ("pt", "doi_PT"),
+            ("en", "doi-en"),
+            ("es", "doi_es"),
+        ]
+        result = cisis.proc_update_doi(file_path, doi, doi_items)
+        expected = ("if 'hf':v706 and v702='xml/abc/v1n1/a.xml' then"
+                    " 'd337d237a237~DOI~','a337~^lpt^ddoi_PT~',"
+                    "'a337~^len^ddoi-en~','a337~^les^ddoi_es~' fi")
+        self.assertEqual(result, expected)
+
+    @patch("app.cisis.datetime")
+    def test_proc_update_datetime(self, mock_dt):
+        file_path = "xml/abc/v1n1/a.xml"
+        mock_dt.now.return_value = datetime(2010, 5, 1, 19, 3, 17)
+        result = cisis.proc_update_datetime(file_path)
+        expected = ("if v706='o' and v702='xml/abc/v1n1/a.xml' then"
+                    " 'd91d92a91~20100501~a92~1903~' fi")
+        self.assertEqual(result, expected)
+
+    @patch("app.cisis.datetime")
+    def test_get_commands_to_update_ohf_records_of_a_doc(self, mock_dt):
+        mock_dt.now.return_value = datetime(2010, 5, 1, 19, 3, 17)
+        db = "base"
+        file_path = "xml/a.xml"
+        h_mfn = "4"
+        doi = "DOI"
+        doi_items = [
+            ("pt", "doi_PT"),
+            ("en", "doi-en"),
+            ("es", "doi_es"),
+        ]
+        result = cisis.get_commands_to_update_ohf_records_of_a_doc(
+            db, file_path, h_mfn, doi, doi_items)
+
+        self.assertEqual(
+            result[0],
+            (
+                "cisis/mx base from=3 count=1 \"proc="
+                "if v706='o' and v702='xml/a.xml' then"
+                " 'd91d92a91~20100501~a92~1903~' fi\" "
+                "copy=base now -all"
+            )
+        )
+        self.assertEqual(
+            result[1],
+            (
+                "cisis/mx base from=4 count=2 \"proc="
+                "if 'hf':v706 and v702='xml/a.xml' then"
+                " 'd337d237a237~DOI~','a337~^lpt^ddoi_PT~',"
+                "'a337~^len^ddoi-en~','a337~^les^ddoi_es~' fi\" "
+                "copy=base now -all"
+            )
+        )

--- a/proc/scielo_doi/tests/test_cisis.py
+++ b/proc/scielo_doi/tests/test_cisis.py
@@ -27,7 +27,7 @@ class TestCisis(TestCase):
         ]
         result = cisis.proc_update_doi(file_path, doi, doi_items)
         expected = ("if 'hf':v706 and v702='xml/abc/v1n1/a.xml' then "
-                    "'d337d237a237~10.1590/1809-4392201902421.1~',"
+                    "'d337d237a237~10.1590/1809-4392201902421~',"
                     "'a337~^lpt^d10.1590/1809-4392201902421.1~',"
                     "'a337~^len^d10.1590/1809-4392201902421.2~',"
                     "'a337~^les^d10.1590/1809-4392201902421.3~' fi")

--- a/proc/scielo_doi/tests/test_cisis.py
+++ b/proc/scielo_doi/tests/test_cisis.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch
-from datetime import datetime
+
 
 from app import cisis
 
@@ -20,41 +19,41 @@ class TestCisis(TestCase):
 
     def test_proc_update_doi(self):
         file_path = "xml/abc/v1n1/a.xml"
-        doi = "DOI"
+        doi = "10.1590/1809-4392201902421"
         doi_items = [
-            ("pt", "doi_PT"),
-            ("en", "doi-en"),
-            ("es", "doi_es"),
+            ("pt", "10.1590/1809-4392201902421.1"),
+            ("en", "10.1590/1809-4392201902421.2"),
+            ("es", "10.1590/1809-4392201902421.3"),
         ]
         result = cisis.proc_update_doi(file_path, doi, doi_items)
-        expected = ("if 'hf':v706 and v702='xml/abc/v1n1/a.xml' then"
-                    " 'd337d237a237~DOI~','a337~^lpt^ddoi_PT~',"
-                    "'a337~^len^ddoi-en~','a337~^les^ddoi_es~' fi")
+        expected = ("if 'hf':v706 and v702='xml/abc/v1n1/a.xml' then "
+                    "'d337d237a237~10.1590/1809-4392201902421.1~',"
+                    "'a337~^lpt^d10.1590/1809-4392201902421.1~',"
+                    "'a337~^len^d10.1590/1809-4392201902421.2~',"
+                    "'a337~^les^d10.1590/1809-4392201902421.3~' fi")
         self.assertEqual(result, expected)
 
-    @patch("app.cisis.datetime")
-    def test_proc_update_datetime(self, mock_dt):
+    def test_proc_update_datetime(self):
         file_path = "xml/abc/v1n1/a.xml"
-        mock_dt.now.return_value = datetime(2010, 5, 1, 19, 3, 17)
-        result = cisis.proc_update_datetime(file_path)
+        result = cisis.proc_update_datetime(file_path, '20100501', '1903')
         expected = ("if v706='o' and v702='xml/abc/v1n1/a.xml' then"
                     " 'd91d92a91~20100501~a92~1903~' fi")
         self.assertEqual(result, expected)
 
-    @patch("app.cisis.datetime")
-    def test_get_commands_to_update_ohf_records_of_a_doc(self, mock_dt):
-        mock_dt.now.return_value = datetime(2010, 5, 1, 19, 3, 17)
+    def test_get_commands_to_update_ohf_records_of_a_doc(self):
         db = "base"
         file_path = "xml/a.xml"
         h_mfn = "4"
-        doi = "DOI"
+        doi = "10.1590/1809-4392201902421.1"
         doi_items = [
-            ("pt", "doi_PT"),
-            ("en", "doi-en"),
-            ("es", "doi_es"),
+            ("pt", "10.1590/1809-4392201902421.1"),
+            ("en", "10.1590/1809-4392201902421.2"),
+            ("es", "10.1590/1809-4392201902421.3"),
         ]
+        upd_date = '20100501'
+        upd_time = '1903'
         result = cisis.get_commands_to_update_ohf_records_of_a_doc(
-            db, file_path, h_mfn, doi, doi_items)
+            db, file_path, h_mfn, doi, doi_items, upd_date, upd_time)
 
         self.assertEqual(
             result[0],
@@ -69,9 +68,11 @@ class TestCisis(TestCase):
             result[1],
             (
                 "cisis/mx base from=4 count=2 \"proc="
-                "if 'hf':v706 and v702='xml/a.xml' then"
-                " 'd337d237a237~DOI~','a337~^lpt^ddoi_PT~',"
-                "'a337~^len^ddoi-en~','a337~^les^ddoi_es~' fi\" "
+                "if 'hf':v706 and v702='xml/a.xml' then "
+                "'d337d237a237~10.1590/1809-4392201902421.1~',"
+                "'a337~^lpt^d10.1590/1809-4392201902421.1~',"
+                "'a337~^len^d10.1590/1809-4392201902421.2~',"
+                "'a337~^les^d10.1590/1809-4392201902421.3~' fi\" "
                 "copy=base now -all"
             )
         )


### PR DESCRIPTION
#### O que esse PR faz?
Cria o módulo cisis e testes para gerar comandos para atualizar uma dada base com dados de DOI (veja a proposta completa (não aprovada) em #713)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Dentro `proc/scielo_doi`, execute:

`python setup.py test`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#713

### Referências
n/a
