### PR TITLE
Altera exibição de ISSN no abstract e no como citar do artigo

### DIFF
--- a/htdocs/xsl/sci_artref.xsl
+++ b/htdocs/xsl/sci_artref.xsl
@@ -7,7 +7,16 @@
 	<xsl:variable name="PATH_WXIS" select="//PATH_WXIS"/>
 	<xsl:variable name="PATH_DATA_IAH" select="//PATH_DATA_IAH"/>
 	<xsl:variable name="PATH_CGI_IAH" select="//PATH_CGI_IAH"/>
-	<xsl:variable name="ISSUE_ISSN" select="//ISSUE_ISSN"/>
+	<xsl:variable name="ISSUE_ISSN">
+		<xsl:choose>
+			<xsl:when test="//ISSUE_ISSN[@TYPE='ONLIN']">
+				<xsl:value-of select="//ISSUE_ISSN[@TYPE='ONLIN']"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="//ISSUE_ISSN"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:variable>
 	<xsl:template name="GetStrip">
 		<xsl:param name="vol"/>
 		<xsl:param name="num"/>


### PR DESCRIPTION
#### O que esse PR faz?
Exibe prioritariamente o ISSN online. Caso não exista, exibe o que existir em `ISSUE_ISSN`.

#### Onde a revisão poderia começar?
Em `htdocs/xsl/sci_artref.xsl`

#### Como este poderia ser testado manualmente?
- Acesse o Abstract de um artigo
- Verifique que o ISSN online do periódico, caso exista, é exibido na legenda como no exemplo [1]
- Acesse o Como Citar do artigo
- Verifique que o ISSN online do periódico, caso exista, é exibido como no exemplo [2]

#### Algum cenário de contexto que queira dar?
.

### Screenshots
[1] - Abstract do artigo
<img width="876" alt="Screen Shot 2020-05-13 at 16 08 55" src="https://user-images.githubusercontent.com/18053487/81854642-9f335180-9534-11ea-81a1-c9ed95cc246d.png">

[2] - Como citar do artigo
<img width="768" alt="Screen Shot 2020-05-13 at 16 09 26" src="https://user-images.githubusercontent.com/18053487/81854697-b40fe500-9534-11ea-8f56-ca49a50e216b.png">

#### Quais são tickets relevantes?
#719

### Referências
.
