### PR TITLE
Considera a formatação "italic" na apresentação das palavras-chave

### DIFF
--- a/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
+++ b/htdocs/xsl/pmc/v3.0/scielo-fulltext.xsl
@@ -369,7 +369,7 @@
 	<!--Adiciona vírgulas as palavras-chave-->
 	<xsl:template match="kwd">
 		<xsl:if test="position()!= 1">; </xsl:if>
-		<xsl:value-of select="."/>
+		<xsl:apply-templates select="*|text()"/>
 	</xsl:template>
 	<xsl:template name="main-title"
 		match="abstract/title | body/*/title |


### PR DESCRIPTION
#### O que esse PR faz?
Considera a formatação "italic" na apresentação das palavras-chave, ou seja, se foram identificadas em itálico, preservar a formatação

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessar os links apresentados no issue #724 e observar que as palavras chaves mencionadas estão em itálico

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
 
<img width="928" alt="Captura de Tela 2020-06-18 às 09 53 31" src="https://user-images.githubusercontent.com/505143/85023916-b674e880-b14b-11ea-8caf-06437a6dcaee.png">

#### Quais são tickets relevantes?
#724 

### Referências
n/a
