### PR TITLE
Adiciona campo ORCID em sci_common.xis

### DIFF
--- a/cgi-bin/ScieloXML/sci_common.xis
+++ b/cgi-bin/ScieloXML/sci_common.xis
@@ -1788,7 +1788,8 @@
 						('<AFF xref="',v1300,'"/>'/)
 					fi
       			    |    <NAME><![CDATA[|v9810^n|]]></NAME>|,/
-		    	    |    <SURNAME><![CDATA[|v9810^s|]]></SURNAME>|/                    
+		    	    |    <SURNAME><![CDATA[|v9810^s|]]></SURNAME>|,/
+		    	    |    <ORCID><![CDATA[|v9810^k|]]></ORCID>|/                    
                     fi 
                 </pft>
             </display>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o campo ORCID no script sci_common.xis. Isso torna possível que qualquer IsisScript que import sci_common.xis obtenha os códigos ORCID dos autores dos documentos (quando disponíveis).

#### Onde a revisão poderia começar?
Pelo único commit que faz a adição do ORCID

#### Como este poderia ser testado manualmente?
1. Instalar instância da aplicação SciELO Metodologia
2. Copiar o arquivo sci_common.xis para a pasta `scielo/cgi-bin/ScieloXML` apontada pelo SciELO Metodologia
3. Visualizar os dados novos por meio de URL. Por exemplo, via `cgi-bin/wxis.exe?IsisScript=ScieloXML/sci_arttext.xis&pid={PID}&PATH_TRANSLATED=../htdocs` em que {PID} é o código PID do documento SciELO a ser consultado
5. Verificar que o campo ORCID é apresentado para cada autor do documento consultado.

#### Algum cenário de contexto que queira dar?
Este PR é parte de uma tarefa maior que consiste em construir uma base de dados de documentos e referências citadas. A ideia principal é obter essas informações de modo ativo, por meio do protocolo OAI-PMH.

### Screenshots
![image](https://user-images.githubusercontent.com/2096125/118538579-c19e1300-b724-11eb-8ed1-cd742b59a21f.png)

#### Quais são tickets relevantes?
#737

### Referências
N/A

