### PR TITLE
Adiciona capacida de sci_getrecord.xis retornar resumo e palavras-chave em todos os idiomas

### DIFF
--- a/cgi-bin/ScieloXML/sci_getrecord.xis
+++ b/cgi-bin/ScieloXML/sci_getrecord.xis
@@ -8,6 +8,22 @@
 <include>ScieloXML/sci_getdefine.xis</include>
 
 
+<function name="CreateArticleAbstractAllLangsXML" action="replace" split="occ" tag="4001">
+<!-- Generate XML for abstract in available languages -->
+	<!--
+    	v8000: XML ou ausente
+    	v4001: conteudo de abstracts
+    -->
+	<field action="replace"	tag="1000">
+		<pft>if v8000='BODY' or a(v8000) then '^i<![CDATA[^f]]>' fi</pft>
+	</field>
+	
+	<display>
+		<pft>
+			('  <ABSTRACT LANG="',v4001^l,'">',v1000^i[1],v4001^a,v1000^f[1],'</ABSTRACT>'/#)
+		</pft>
+	</display>
+</function>
 <function name="CreateArticleAllTitlesXML" action="replace" tag="4001">
 <!-- Generate XML for Title of Article
      ^r - MFN 
@@ -160,6 +176,12 @@
 	<call name="TestPDFPresence"><pft>if v8264<>'no' then v4001^p fi</pft></call>
    
 	<display><pft>'>'/</pft></display>
+
+	<call name="CreateArticleAbstractAllLangsXML">
+        <pft>
+            (v83/)
+        </pft>
+    </call>
 	<display><pft>if p(v264) then '<EMBARGO date="',v264,'" text="',v8264,'"/>'/ fi</pft></display>
 	
 	<!-- <call name="insertElementRelatedToDocument"><pft>if p(v241) or p(v41) then  (v880[1],|^x|v41[1],v241,|^v|v31[1],|^w|v131[1],|^n|v32[1],|^y|v132[1],|^d|v65[1]*0.4/) fi</pft></call> -->

--- a/cgi-bin/ScieloXML/sci_getrecord.xis
+++ b/cgi-bin/ScieloXML/sci_getrecord.xis
@@ -24,6 +24,26 @@
 		</pft>
 	</display>
 </function>
+
+<function name="CreateKeywordsGroupAllLangsXML" action="replace" tag="4001">
+<!-- Generate XML for Publishers Groups 4001 - Publishers -->
+    <field action="replace" tag="85" split="occ"><pft>(v4001/)</pft></field>
+ 		
+	<display>
+		<pft>
+			(
+				if p(v85^k) then
+					'  <KEYWORD LANG="',v85^l,'">'/,
+						'   <KEY><![CDATA[',v85^k,']]></KEY>'/,
+						|   <SUBKEY><![CDATA[|v85^s|]]></SUBKEY>|/,
+					'  </KEYWORD>'/,
+				fi
+			)
+		</pft>
+	</display>	
+</function>
+
+
 <function name="CreateArticleAllTitlesXML" action="replace" tag="4001">
 <!-- Generate XML for Title of Article
      ^r - MFN 
@@ -182,6 +202,13 @@
             (v83/)
         </pft>
     </call>
+		
+	<call name="CreateKeywordsGroupAllLangsXML">
+        <pft>
+        	(v85/)
+        </pft>
+    </call>
+
 	<display><pft>if p(v264) then '<EMBARGO date="',v264,'" text="',v8264,'"/>'/ fi</pft></display>
 	
 	<!-- <call name="insertElementRelatedToDocument"><pft>if p(v241) or p(v41) then  (v880[1],|^x|v41[1],v241,|^v|v31[1],|^w|v131[1],|^n|v32[1],|^y|v132[1],|^d|v65[1]*0.4/) fi</pft></call> -->


### PR DESCRIPTION
#### O que esse PR faz?
Tornar o script `sci_getrecord.xis` capaz de retornar resumo e palavras-chave em todos os idiomas disponíveis.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Instalar instância da aplicação SciELO Metodologia
2. Copiar o arquivo sci_getrecord.xis para a pasta `scielo/cgi-bin/ScieloXML` apontada pelo SciELO Metodologia
3. Acessar o IsisScript por meio de URL: `cgi-bin/wxis.exe?IsisScript=ScieloXML/sci_getrecord.xis&pid={PID}&PATH_TRANSLATED=../htdocs` em que {PID} é o código PID do documento SciELO a ser consultado
4. Verificar a existência dos campos novos `ABSTRACT` e `KEYWORDS` (para todos os idiomas disponíveis do artigo consultado).

#### Algum cenário de contexto que queira dar?
Este PR é parte de uma tarefa maior que consiste em criar um novo prefixo de metadados OAI-PMH. É preciso que os sites clássicos disponibilizem mais informações em relação aos seus documentos. Este PR adiciona no novo IsisScript a capacidade de retornar o resumo em todos os idiomas disponíveis (assim como as palavras-chave). A vantagem é permitir a obtenção de mais dados fazendo apenas uma consulta ao Provedor OAI-PMH. 

### Screenshots
__Abstracts__
![image](https://user-images.githubusercontent.com/2096125/118829870-e31e0c80-b894-11eb-9ee4-93a1e0991d7a.png)

__Keywords__
![image](https://user-images.githubusercontent.com/2096125/118829909-ee713800-b894-11eb-8dc0-8825158c6cb0.png)

#### Quais são tickets relevantes?
Closes #740 

### Referências
N/A

