### PR TITLE
Corrige sci_getrecord para retornar documentos ahead

### DIFF
--- a/cgi-bin/ScieloXML/sci_getrecord.xis
+++ b/cgi-bin/ScieloXML/sci_getrecord.xis
@@ -24,7 +24,7 @@
 
 	<!-- 5 - Title MFN, 6 - Issue MFN, 7 - Article MFN -->  
 	<field action="replace" tag="5"><pft>f(l(['TITLE']'LOC='mid(v1,2,9)),1,0)</pft></field>
-	<field action="replace" tag="6"><pft>f(l(['NEWISSUE'],mid(v1,2,17)),1,0)</pft></field>
+	<field action="replace" tag="6"><pft>f(l(['NEWISSUE']v3331,mid(v1,2,17)),1,0)</pft></field>
 	<field action="replace" tag="7"><pft>f(l(['ARTIGO']'HR='v1),1,0)</pft></field>
 
 	<!-- Article text language -->

--- a/htdocs/versionOverview.txt
+++ b/htdocs/versionOverview.txt
@@ -1,3 +1,6 @@
+v5.44
+Corrige script sci_getrecord.xis para retornar corretamente documentos ahead
+
 v5.43
 Resolve problema de indisponibilidade de algumas páginas de resumo por conter problema na geração do `<citation_title/>` (#733)
 Inclusão de novos IsisScripts sci_record.xis e sci_getrecord.xis responsáveis por obter dados completos de documentos, inclusive referências citadas


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o script `sci_getrecord.xis` de modo que ele consiga retornar corretamente documentos `ahead` (descrito no issue #748). Finaliza a tarefa "Disponibilizar por meio de um novo prefixo de metadados OAI-PMH dados mais completos de documentos e respectivas referências citadas" - sugere-se encerrar os issues #735, #737, #743 e #748).

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
Deve-se acessar a versão não corrigida, em old.scielo, e a versão corrigida, na máquina local. Na versão não corrigida, qualquer documento `ahead` não deve ser retornado pelo script sci_getrecord.xis (pois há um bug). Os seguintes links são exemplos de dados inacessíveis por causa do bug: 
1. https://old.scielo.br/cgi-bin/wxis.exe/?IsisScript=ScieloXML/sci_getrecord.xis&pid=S0066-782X2019005022109
2. https://old.scielo.br/oai/scielo-oai.php?verb=GetRecord&metadataPrefix=oai_dc_scielo&identifier=oai:scielo:S0066-782X2019005022109

A versão corrigida, na máquina local, deve retornar esses dados corretamente.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

