### PR TITLE
Corrige script sci_listrecords_scielo.xis para retornar documentos AHEAD corretamente

### DIFF
--- a/cgi-bin/ScieloXML/sci_listrecords_scielo.xis
+++ b/cgi-bin/ScieloXML/sci_listrecords_scielo.xis
@@ -175,7 +175,7 @@
                     </pft>
                 </flow>
 
-                <field action="replace" tag="6"><pft>f(l(['NEWISSUE'],mid(v1880,2,17)),1,0)</pft></field>
+                <field action="replace" tag="6"><pft>f(l(['NEWISSUE']'Y',mid(v1880,2,17)),1,0)</pft></field>
                 <field action="replace" tag="11"><pft>if a(v11) then ref(['ARTIGO']val(v1003^m),@PROC_SPLIT_MST.PFT,v40) fi</pft></field>
 
                 <call name="CreateArticleXML">


### PR DESCRIPTION
#### O que esse PR faz?
Corrige acesso ao verbo ListRecords com o prefixo de metadados oai_dc_scielo. Adiciona caratere 'Y' ao chamar função `l` para a base NEWISSUE. E isso corrige a situação em que o verbo ListRecords em conjunto com o prefixo de metadados oai_dc_scielo falha ao obter dados de documentos AHEAD. O verbo GetRecord não possui esse problema (foi corrigido em commits anteriores).

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Acessar o endereço 0.0.0.0/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc_scielo&from=2020-02-07&resumptionToken=DTH__20200207__0066-782X2019000700100::2020-02-07:2099-12-30:oai_dc_scielo
2. Acessar o endereço 0.0.0.0/oai/scielo-oai.php?verb=ListRecords&metadataPrefix=oai_dc_scielo&from=2021-07-01
3. Observar que os dados são retornados corretamente (no domínio old.scielo.br esses dados não são retornados pois há uma falha no script sci_listrecords_scielo.xis)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#748 

### Referências
N/A