### PR TITLE
Adiciona um fluxo alternativo e mais rápido ("fast") de geração e envio de artigos para o ArticleMeta

### DIFF
--- a/proc/Envia2SciELOFast.bat
+++ b/proc/Envia2SciELOFast.bat
@@ -4,14 +4,15 @@ rem ===== Aumentar o espaco de variaveis de ambiente
 rem CONFIG.SYS
 rem 
 
-rem Envia2Medline
+rem Envia2SciELOFast
 rem Parametro 1: path da producao da SciELO
 rem Parametro 2: arquivo com instrucoes de FTP
 rem Parametro 3: arquivo de log
 rem Parametro 4: cria / adiciona
+rem Parametro 5: (Opcional) path alternativo da base de artigos
 
 rem Inicializa variaveis
-export INFORMALOG=log/Envia2Medline.log
+export INFORMALOG=log/Envia2SciELOFast.log
 export CISIS_DIR=cisis
 
 rem Verifica parametros
@@ -34,7 +35,12 @@ call batch/CriaDiretorio.bat temp/transf2scielofast
 call batch/GeraIso.bat $1/title/title temp/transf2scielofast/title_full.iso
 
 call batch/CriaMaster.bat temp/transf2scielofast/artigo_full_temp
-call batch/AppendMaster.bat $1/artigo/artigo temp/transf2scielofast/artigo_full_temp prc/apaga_autores_772.prc
+ARTIGOSOURCE=$1/artigo/artigo
+if [ "$5" != "" ]
+then
+   ARTIGOSOURCE=$5
+fi
+call batch/AppendMaster.bat ${ARTIGOSOURCE} temp/transf2scielofast/artigo_full_temp prc/apaga_autores_772.prc
 
 call batch/GeraIso.bat temp/transf2scielofast/artigo_full_temp temp/transf2scielofast/artigo_full.iso
 

--- a/proc/GeraScielo.bat
+++ b/proc/GeraScielo.bat
@@ -58,6 +58,41 @@ call batch/GeraInvertido.bat ../bases-work/newissue/newissue fst/newissue.fst ..
 
 call batch/CriaRevistasNovas.bat $1
 call batch/GeraIssues.bat $1
+
+# ==============================================================================
+# PROPOSITO: GeraArtigoFast.bat
+
+GERAPADRAO_STATUS=""
+ARQUIVO_STATUS="temp/GeraArtigoFastGeraPadraoStatus.ctrl"
+
+# 1. Le o status removendo potenciais quebras de linha do Windows (\r)
+if [ -f "${ARQUIVO_STATUS}" ]
+then
+   GERAPADRAO_STATUS=$(tr -d '\r' < "${ARQUIVO_STATUS}" 2>/dev/null)
+fi
+
+# 2. Desvio condicional para o modo FAST
+if [ "${GERAPADRAO_STATUS}" == "RUNNING" ]
+then
+   call batch/GeraArtigoFastLockCheck.bat ${ARQUIVO_STATUS} 72 tecnologia@scielo.org
+
+   call batch/InformaLog.bat $0 dh === Executando Fluxo FAST (Status: RUNNING) ===
+
+   # Executa o batch especial para o fluxo rápido
+   call batch/GeraArtigoFast.bat $1
+
+   # Registra o fim antecipado no log e encerra com sucesso (exit 0)
+   call batch/InformaLog.bat $0 dh === Fim Antecipado (Fluxo FAST) === LOG gravado em: $INFORMALOG
+   
+   # Finaliza execucao com sucesso, mas sem finalizar de forma padrão
+   exit 0
+fi
+
+# ==============================================================================
+# PROPOSITO: GeraArtigoFast.bat
+echo "RUNNING" > "${ARQUIVO_STATUS}"
+# ==============================================================================
+
 call batch/GeraArtigo.bat $1
 
 call batch/GeraFacCount.bat $1
@@ -77,5 +112,10 @@ rem REPOSITORIO FIM
 call batch/ManutencaoOn.bat ../bases
 call batch/CopiaWork2Teste.bat ../bases-work ../bases
 call batch/ManutencaoOff.bat ../bases
+
+# ==============================================================================
+# PROPOSITO: GeraArtigoFast.bat
+echo "FINISHED" > "${ARQUIVO_STATUS}"
+# ==============================================================================
 
 call batch/InformaLog.bat $0 dh ===Fim=== LOG gravado em: $INFORMALOG

--- a/proc/batch/GeraArtigoFast.bat
+++ b/proc/batch/GeraArtigoFast.bat
@@ -1,0 +1,16 @@
+rem GeraArtigoFast
+rem Parametro 1: path producao Scielo
+
+call batch/VerifPresencaParametro.bat $0 @$1 path producao SciELO
+
+call batch/CriaDiretorio.bat ../bases-work/fast
+call batch/CriaMaster.bat ../bases-work/fast/artigo
+
+$CISIS_DIR/mx $1/serial/title/title lw=9000 "pft=if v50='C' then 'call batch/AppendMaster.bat ../bases-work/',v68,'/',v68,x1,'../bases-work/fast/artigo',x1,'prc/d1930.prc'/ fi" now >temp/GeraArtigoFast.bat
+batch/ifErrorLevel.bat $? batch/AchouErro.bat $0 mx $1/serial/title/title lw:9000 pft:call_GeraArtigo.bat
+chmod 700 temp/GeraArtigoFast.bat
+call temp/GeraArtigoFast.bat
+
+echo "GeraArtigoFast: Envia de bases title e artigo do bases-work para FTP para carga em ArticleMeta"
+call Envia2SciELOFast.bat ../bases-work transf/Envia2SciELOFastLogOn.txt log/enviaGeraArtigoFast.log cria ../bases-work/fast/artigo
+echo "GeraArtigoFast: Fim de envio de bases"

--- a/proc/batch/GeraArtigoFastLockCheck.bat
+++ b/proc/batch/GeraArtigoFastLockCheck.bat
@@ -1,0 +1,23 @@
+#!/bin/bash
+ARQUIVO="${1:-temp/GeraArtigoFastGeraPadraoStatus.ctrl}"
+LIMIAR="${2:-72}"
+EMAIL="${3:-tecnologia@scielo.org}"
+
+[ -f "$ARQUIVO" ] || exit 0
+[ "$(tr -d '\r' < "$ARQUIVO")" == "RUNNING" ] || exit 0
+
+MTIME=$(stat -c %Y "$ARQUIVO" 2>/dev/null || stat -f %m "$ARQUIVO")
+IDADE=$(( ($(date +%s) - MTIME) / 3600 ))
+[ "$IDADE" -ge "$LIMIAR" ] || exit 0
+
+DESDE=$(date -d "@$MTIME" +%d/%m/%Y\ %H:%M:%S 2>/dev/null || date -r "$MTIME" +%d/%m/%Y\ %H:%M:%S)
+
+cat >temp/GeraArtigoFastGeraPadraoStatusMessage.txt <<!
+A equipe de Infraestrutura,
+Processamento GeraPadrao esta executando ha ${IDADE}h (limite: ${LIMIAR}h), status RUNNING desde ${DESDE}.
+Favor verificar.
+Processamento SciELO
+!
+mailx -s "[ALERTA-GeraArtigoFast] GeraPadrao RUNNING ${IDADE}h desde ${DESDE}" "$EMAIL" < temp/GeraArtigoFastGeraPadraoStatusMessage.txt
+rm temp/GeraArtigoFastGeraPadraoStatusMessage.txt
+


### PR DESCRIPTION
## O que esse PR faz?
Adiciona um fluxo alternativo e mais rápido ("fast") de geração e envio de artigos para o ArticleMeta, permitindo que o `GeraSciELO` continue publicando artigos correntes via FTP durante as janelas em que o processamento completo (`GeraPadrao`, que leva cerca de 3 dias) ainda está em execução — em vez de bloquear novas execuções ou aguardar o pipeline completo terminar.

Para isso, este PR:
- Introduz um arquivo de controle de status (`temp/GeraArtigoFastGeraPadraoStatus.ctrl`) que marca o processamento principal como `RUNNING` no início e `FINISHED` ao término.
- Cria `batch/GeraArtigoFast.bat`, que gera e envia apenas os artigos com status corrente (`v50='C'`) via FTP para o ArticleMeta, sem depender da conclusão do pipeline completo.
- Cria `batch/GeraArtigoFastLockCheck.bat`, que verifica há quanto tempo o status está `RUNNING` e envia e-mail de alerta para a equipe de tecnologia caso o limiar (72h) seja ultrapassado, indicando possível travamento do processamento principal.
- Corrige nomenclatura herdada em `proc/Envia2SciELOFast.bat` (referências antigas ao `Envia2Medline`) e adiciona um parâmetro opcional para permitir indicar um path alternativo da base de artigos, necessário para o novo fluxo fast.

## Onde a revisão poderia começar?
Sugiro iniciar por `proc/GeraScielo.bat`, no trecho que verifica o status do arquivo de controle (`ARQUIVO_STATUS`) logo após `call batch/GeraIssues.bat $1` — é ali que a decisão entre fluxo completo e fluxo fast acontece. Em seguida, `batch/GeraArtigoFastLockCheck.bat` (pequeno e autocontido) e `batch/GeraArtigoFast.bat`. Por fim, `proc/Envia2SciELOFast.bat` para entender o parâmetro opcional de origem de artigos usado pelo fluxo fast.

## Como este poderia ser testado manualmente?
1. Executar `proc/GeraScielo.bat` normalmente com os 4 parâmetros esperados; confirmar que `temp/GeraArtigoFastGeraPadraoStatus.ctrl` é criado com conteúdo `RUNNING` logo após o início do processamento pesado.
2. Enquanto essa primeira execução ainda está em andamento (ou simulando manualmente, criando o arquivo `.ctrl` com `RUNNING` antes de rodar), disparar uma segunda execução de `proc/GeraScielo.bat` e confirmar que ela:
   - chama `batch/GeraArtigoFastLockCheck.bat`;
   - executa `batch/GeraArtigoFast.bat` em vez do pipeline completo;
   - encerra com `exit 0` sem reiniciar o processamento completo.
3. Para testar o alerta de travamento: alterar manualmente o `mtime` do arquivo `.ctrl` para mais de 72h atrás (`touch -d "73 hours ago" temp/GeraArtigoFastGeraPadraoStatus.ctrl`) e rodar `batch/GeraArtigoFastLockCheck.bat temp/GeraArtigoFastGeraPadraoStatus.ctrl 72 <email-de-teste>` isoladamente; confirmar recebimento do e-mail de alerta e código de saída `1`.
4. Confirmar que, ao final do processamento completo, o arquivo `.ctrl` é atualizado para `FINISHED` e que uma nova execução após isso segue o fluxo normal (não entra no fluxo fast).
5. Testar `proc/Envia2SciELOFast.bat` com e sem o parâmetro 5 (path alternativo de artigos), confirmando que o comportamento padrão (`$1/artigo/artigo`) é preservado quando o parâmetro é omitido.

## Algum cenário de contexto que queira dar?
O `GeraPadrao` leva cerca de 3 dias para concluir, sendo a indexação da base `bases-work/artigo/artigo` sozinha responsável por ~54h desse tempo. O script principal já é disparado diariamente (cron), então a maior parte das execuções diárias ocorre com o processamento completo ainda em andamento.

Identificamos que existem dois procedimentos que poderiam se beneficiar de um fluxo alternativo durante essa janela: (1) o fluxo do site novo via Kernel/Airflow, que **já é disparado em paralelo** desde o início do `GeraPadrao` e não é afetado por este PR; e (2) o ISIS2mongo, que precisa apenas da base `artigo` sem indexação, gerado diariamente.

**Este PR trata especificamente de um terceiro procedimento**: a publicação de artigos correntes via FTP para o ArticleMeta (`GeraArtigoFast` / `Envia2SciELOFast`), permitindo que ela ocorra diariamente enquanto o `GeraPadrao` está em execução. Este PR **não** trata da geração da base `artigo` não indexada para consumo do ISIS2mongo, nem do fluxo de sincronização com o Kernel/Airflow (já existente) — esses ficam para tratamento em issues/PRs separados.

## Screenshots
Não aplicável — mudanças em scripts de shell/backend, sem interface gráfica.

## Quais são os tickets relevantes?
<!-- Indicar aqui a issue relacionada ao fluxo mais amplo (Kernel/Airflow + ISIS2mongo + ArticleMeta), ex.: #123 -->

## Referências
<!-- Indicar aqui documentação interna, RFCs ou discussões relacionadas, se houver -->

---

## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)